### PR TITLE
feat: multi-module support

### DIFF
--- a/contrib/dutagent-cfg-example.yaml
+++ b/contrib/dutagent-cfg-example.yaml
@@ -34,5 +34,7 @@ devices:
       file-transfer:
         desc: "Transfer a file"
         modules:
+          - module: dummy-status
+            args: "foo bar"
           - module: dummy-ft
             main: true

--- a/pkg/dut/dut.go
+++ b/pkg/dut/dut.go
@@ -29,8 +29,6 @@ type Command struct {
 type commandAlias Command
 
 // UnmarshalYAML unmarshals a Command from a YAML node and adds custom validation.
-//
-//nolint:cyclop
 func (c *Command) UnmarshalYAML(node *yaml.Node) error {
 	var cmd commandAlias
 	if err := node.Decode(&cmd); err != nil {
@@ -56,10 +54,6 @@ func (c *Command) UnmarshalYAML(node *yaml.Node) error {
 	for _, mod := range c.Modules {
 		if mod.Config.Main && mod.Config.Args != nil {
 			return errors.New("main module should not have args set, they are passed as command line arguments")
-		}
-
-		if !mod.Config.Main && mod.Config.Args == nil {
-			return errors.New("non-main modules should have args set")
 		}
 	}
 


### PR DESCRIPTION
Add missing implementation according to the dutagent config spec:

> A command may be composed of multiple steps to achieve its purpose. The list of modules represent these steps.The order of this list is important, though. Exactly one of the modules must be set as the main module.