### PR TITLE
ci: use private access token (PAT) in release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
       


### PR DESCRIPTION
See https://github.com/googleapis/release-please-action?tab=readme-ov-file#github-credentials

E.g without it the commitlint workflow would not run in the Release-PR created by Release Please.