### PR TITLE
Pass arguments to non-main modules as array

### DIFF
--- a/cmds/dutagent/runRPC.go
+++ b/cmds/dutagent/runRPC.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 
 	"connectrpc.com/connect"
 	"github.com/BlindspotSoftware/dutctl/internal/dutagent"
@@ -152,7 +151,7 @@ func executeModules(ctx context.Context, args runCmdArgs) (runCmdArgs, fsm.State
 			if module.Config.Main {
 				moduleArgs = args.cmdMsg.GetArgs()
 			} else {
-				moduleArgs = strings.Split(module.Config.Args, " ")
+				moduleArgs = module.Config.Args
 			}
 
 			err := module.Run(rpcCtx, moduleSession, moduleArgs...)

--- a/contrib/dutagent-cfg-example.yaml
+++ b/contrib/dutagent-cfg-example.yaml
@@ -34,6 +34,8 @@ devices:
         desc: "Transfer a file"
         modules:
           - module: dummy-status
-            args: "foo bar"
+            args: 
+              - foo
+              - bar
           - module: dummy-ft
             main: true

--- a/docs/dutagent-config.md
+++ b/docs/dutagent-config.md
@@ -42,7 +42,7 @@ could look like.
 | --- | --- | --- | --- | --- |
 | module | string |  | The module's name also serves as its identifier and must be unique. | yes |
 | main | bool | false | All arguments to a command are passed to its main module. The main modules usage information is also used as the command help text. | exactly once per command |
-| args | string | nil | If a module is not an commands main module, it does not get any arguments passed at runtime, instead arguments can be passed here.| when main is false |
+| args | []string | nil | If a module is not an commands main module, it does not get any arguments passed at runtime, instead arguments can be passed here.| when main is false |
 | options | map[string]any |  | A module can be configured via key-value pairs. The type of the value is generic and depends on the implementation of the module.| yes |
 
 

--- a/pkg/dut/dut.go
+++ b/pkg/dut/dut.go
@@ -120,7 +120,7 @@ func (c *Command) UnmarshalYAML(node *yaml.Node) error {
 
 	// Check for presence of args in non-main modules only
 	for _, mod := range c.Modules {
-		if mod.Config.Main && mod.Config.Args != "" {
+		if mod.Config.Main && len(mod.Config.Args) > 0 {
 			return errors.New("main module should not have args set. They are passed as command line arguments via the dutctl client")
 		}
 	}
@@ -150,7 +150,7 @@ type Module struct {
 type ModuleConfig struct {
 	Name    string `yaml:"module"`
 	Main    bool
-	Args    string
+	Args    []string
 	Options map[string]any
 }
 


### PR DESCRIPTION
Arguments are passed to modules as a string array generally. And for main modules, they are originally taken from the command line of the dutctl command (passed via RPC to the dutagent and finally to the module). From the earliest occurrence the arguments are stored as an array of strings as the go runtime passes the command line arguments ( of dutctl in this case) to the program in such way.

Now for non-main modules, arguments can be passed to modules via the dutagent config file. For convenience, the respective config field was designed to be a string. As a result, this string has to be split up into a list of arguments. However, just splitting the string based on spaces is not sufficient because this does not consider e.g. quoting.

An elegant solution would introduce a lexer that splits up the string the same way the command line ends up in os.Args array. But for now, this fix just changes the respective field in the dutagent config into a string array.

BREAKING CHANGE: `args` field of module object in dutagent config is now a string array.