### PR TITLE
feat: module PDU

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ For details on the system architecture see [docs](./docs).
 | ------------------- | ---------------------------- |
 | Linux               | RaspberryPi 4                |
 
-| Modules                                            | Status             |
-| -------------------------------------------------- | ------------------ |
-| [GPIO Button](./pkg/module/gpio/README.md)         | :white_check_mark: |
-| [GPIO Switch](./pkg/module/gpio/README.md)         | :white_check_mark: |
-| [IPMI Power Control](./pkg/module/gpio/README.md)  | :white_check_mark: |
-| Power Distribution Unit, Intellinet                | :x:                |
-| Power Distribution Unit, Delock                    | :x:                |
-| SPI Flasher, dediprog                              | :x:                |
-| SPI Flasher, flashrom                              | :x:                |
-| SPI Flasher, flashprog                             | :x:                |
-| SPI Flasher, em100                                 | :x:                |
-| [Serial Console](./pkg/module/serial/README.md)    | :white_check_mark: |
-| [Shell Execution](./pkg/module/shell/README.md)    | :white_check_mark: |
-| [Secure Shell (SSH)](./pkg/module/ssh/README.md)   | :white_check_mark: |
+| Modules                                                           | Status             |
+| ----------------------------------------------------------------- | ------------------ |
+| [GPIO Button](./pkg/module/gpio/README.md)                        | :white_check_mark: |
+| [GPIO Switch](./pkg/module/gpio/README.md)                        | :white_check_mark: |
+| [IPMI Power Control](./pkg/module/gpio/README.md)                 | :white_check_mark: |
+| [Power Distribution Unit, Intellinet](./pkg/module/pdu/README.md) | :white_check_mark: |
+| Power Distribution Unit, Delock                                   | :x:                |
+| SPI Flasher, dediprog                                             | :x:                |
+| SPI Flasher, flashrom                                             | :x:                |
+| SPI Flasher, flashprog                                            | :x:                |
+| SPI Flasher, em100                                                | :x:                |
+| [Serial Console](./pkg/module/serial/README.md)                   | :white_check_mark: |
+| [Shell Execution](./pkg/module/shell/README.md)                   | :white_check_mark: |
+| [Secure Shell (SSH)](./pkg/module/ssh/README.md)                  | :white_check_mark: |
 
 
 

--- a/cmds/dutagent/modules.go
+++ b/cmds/dutagent/modules.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/dummy"
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/gpio"
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/ipmi"
+	_ "github.com/BlindspotSoftware/dutctl/pkg/module/pdu"
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/serial"
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/shell"
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/ssh"

--- a/pkg/module/pdu/README.md
+++ b/pkg/module/pdu/README.md
@@ -1,0 +1,35 @@
+# PDU
+
+The **PDU** module provides basic power control of a Power Distribution Unit (PDU) via HTTP requests. It supports turning a power outlet on, off, toggling its state, and querying the current status.
+
+**Note**: This module currently supports only Intellinet ATM PDUs.
+
+This module is intended to be used as part of `dutagent`, allowing automated power control of a DUT (Device Under Test) through a network-accessible PDU.
+
+## Usage
+
+```
+pdu [on|off|toggle|status]
+```
+
+### Commands
+
+| Command  | Description                    |
+| -------- | ------------------------------ |
+| `on`     | Power on the outlet            |
+| `off`    | Power off the outlet           |
+| `toggle` | Toggle the current power state |
+| `status` | Report the current power state |
+
+If no command is provided, the module prints a usage message and exits.
+
+See [pdu-example-cfg.yml](./pdu-example-cfg.yml) for examples. 
+
+## Configuration Options
+
+| Option     | Type   | Description                                    |
+| ---------- | ------ | ---------------------------------------------- |
+| `host`     | string | Base URL of the PDU (e.g. `10.0.0.5`)          |
+| `user`     | string | (Optional) Username for HTTP Basic Auth        |
+| `password` | string | (Optional) Password for HTTP Basic Auth        |
+| `outlet`   | int    | Outlet number to control (0-15, defaults to 0) |

--- a/pkg/module/pdu/pdu-example-cfg.yml
+++ b/pkg/module/pdu/pdu-example-cfg.yml
@@ -1,0 +1,15 @@
+version: 0
+devices:
+  fancy-server:
+    desc: "A server with power control via PDU"
+    cmds:
+      power-on:
+        desc: "Turn the power ON via PDU"
+        modules:
+          - module: pdu
+            main: true
+            options:
+              host: http://192.168.1.100
+              user: admin
+              password: admin
+              outlet: 6

--- a/pkg/module/pdu/pdu.go
+++ b/pkg/module/pdu/pdu.go
@@ -1,0 +1,257 @@
+// Copyright 2024 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pdu provides a dutagent module that allows power control of a PDU via HTTP requests.
+package pdu
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/BlindspotSoftware/dutctl/pkg/module"
+)
+
+func init() {
+	module.Register(module.Record{
+		ID: "pdu",
+		New: func() module.Module {
+			return &PDU{}
+		},
+	})
+}
+
+// PDU is a module that provides basic power management functions for a PDU (Power Distribution Unit).
+// NOTE: This implementation currently supports only Intellinet ATM PDUs.
+type PDU struct {
+	Host     string // Host is the address of the PDU
+	User     string // User is used for authentication, if supported by the PDU
+	Password string // Password is used for authentication, if supported by the PDU
+	Outlet   int    // Outlet is the outlet to control, if the PDU supports multiple outlets. Defaults to 0 (first outlet).
+
+	client     *http.Client // internal HTTP client for request to the PDU
+	controlURL *url.URL     // controlURL is the URL for controlling the PDU outlet
+	statusURL  *url.URL     // statusURL is the URL for getting the PDU status
+}
+
+func (p *PDU) Help() string {
+	log.Println("pdu module: Help called")
+
+	help := strings.Builder{}
+
+	help.WriteString("PDU Power Management Module\n")
+	help.WriteString("\nUsage:\n")
+	help.WriteString("  pdu-power [on|off|toggle|status]\n\n")
+	help.WriteString("Commands:\n")
+	help.WriteString("  on      - Power on the outlet\n")
+	help.WriteString("  off     - Power off the outlet\n")
+	help.WriteString("  toggle  - Toggle the outlet power\n")
+	help.WriteString("  status  - Get current power state\n")
+	help.WriteString("\n")
+	help.WriteString("This module provides basic power control functions via HTTP to a PDU.\n")
+	help.WriteString("The configured PDU has IP: " + p.Host + "\n")
+	help.WriteString(fmt.Sprintf("The configured outlet is: %d\n", p.Outlet))
+
+	return help.String()
+}
+
+const (
+	defaultTimeout = 10 * time.Second // Default timeout for HTTP requests
+	on             = "on"
+	off            = "off"
+	toggle         = "toggle"
+	status         = "status"
+)
+
+func (p *PDU) Init() error {
+	log.Printf("pdu module: Init called - Host: %s, User: %s, Outlet: %d", p.Host, p.User, p.Outlet)
+
+	if p.Outlet < 0 {
+		return fmt.Errorf("invalid outlet number %d: outlet must be 0 or greater", p.Outlet)
+	}
+
+	p.client = &http.Client{Timeout: defaultTimeout}
+
+	controlURL, err := url.Parse(strings.TrimRight(p.Host, "/") + "/control_outlet.htm")
+	if err != nil {
+		return err
+	}
+
+	p.controlURL = controlURL
+
+	statusURL, err := url.Parse(strings.TrimRight(p.Host, "/") + "/status.xml")
+	if err != nil {
+		return err
+	}
+
+	p.statusURL = statusURL
+
+	log.Printf("pdu module: Init completed - controlURL: %s, statusURL: %s", p.controlURL.String(), p.statusURL.String())
+
+	return nil
+}
+
+func (p *PDU) Deinit() error {
+	log.Println("pdu module: Deinit called")
+
+	return nil
+}
+
+func (p *PDU) Run(ctx context.Context, s module.Session, args ...string) error {
+	if p.client == nil {
+		return fmt.Errorf("PDU client not initialized")
+	}
+
+	if p.Host == "" {
+		return fmt.Errorf("PDU host address not configured")
+	}
+
+	if len(args) == 0 {
+		s.Print("No command specified. Call 'help' for usage.")
+
+		return nil
+	}
+
+	cmd := strings.ToLower(args[0])
+
+	switch cmd {
+	case on, off, toggle:
+		return p.setPower(ctx, s, cmd)
+	case status:
+		return p.status(ctx, s)
+	default:
+		s.Print("Unknown command: " + cmd)
+		s.Print("Available commands: on, off, toggle, status")
+
+		return nil
+	}
+}
+
+// doRequest creates and executes an HTTP request with authentication and validates the response.
+func (p *PDU) doRequest(ctx context.Context, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if p.User != "" && p.Password != "" {
+		req.SetBasicAuth(p.User, p.Password)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		return nil, fmt.Errorf("PDU command failed with status %s: %s", resp.Status, string(body))
+	}
+
+	return resp, nil
+}
+
+func (p *PDU) setPower(ctx context.Context, s module.Session, state string) error {
+	opState, err := parseOp(state)
+	if err != nil {
+		return err
+	}
+
+	q := p.controlURL.Query()
+	q.Set(fmt.Sprintf("outlet%d", p.Outlet), "1")
+	q.Set("op", opState.String())
+	p.controlURL.RawQuery = q.Encode()
+
+	resp, err := p.doRequest(ctx, p.controlURL.String())
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	s.Print(fmt.Sprintf("PDU outlet%d power set to '%s' successfully", p.Outlet, state))
+
+	return nil
+}
+
+func (p *PDU) status(ctx context.Context, s module.Session) error {
+	resp, err := p.doRequest(ctx, p.statusURL.String())
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	outletValue, err := p.parseOutletStatus(body)
+	if err != nil {
+		return err
+	}
+
+	s.Print(fmt.Sprintf("PDU outlet%d state: %s", p.Outlet, outletValue))
+
+	return nil
+}
+
+// parseOutletStatus extracts the outlet status from XML response body.
+func (p *PDU) parseOutletStatus(body []byte) (string, error) {
+	bodyStr := string(body)
+
+	outletTag := fmt.Sprintf("<outletStat%d>", p.Outlet)
+	outletEndTag := fmt.Sprintf("</outletStat%d>", p.Outlet)
+
+	startIdx := strings.Index(bodyStr, outletTag)
+	if startIdx == -1 {
+		return "", fmt.Errorf("outlet %d not found in PDU status", p.Outlet)
+	}
+
+	startIdx += len(outletTag)
+
+	endIdx := strings.Index(bodyStr[startIdx:], outletEndTag)
+	if endIdx == -1 {
+		return "", fmt.Errorf("malformed XML for outlet %d", p.Outlet)
+	}
+
+	outletValue := strings.TrimSpace(bodyStr[startIdx : startIdx+endIdx])
+
+	if outletValue != on && outletValue != off {
+		return "", fmt.Errorf("unexpected outlet state '%s' for outlet %d", outletValue, p.Outlet)
+	}
+
+	return outletValue, nil
+}
+
+type op string
+
+const (
+	opOn     op = "0"
+	opOff    op = "1"
+	opToggle op = "2"
+)
+
+func (o op) String() string {
+	return string(o)
+}
+
+func parseOp(state string) (op, error) {
+	switch state {
+	case on:
+		return opOn, nil
+	case off:
+		return opOff, nil
+	case toggle:
+		return opToggle, nil
+	default:
+		return "", fmt.Errorf("invalid PDU operation: %s", state)
+	}
+}

--- a/pkg/module/pdu/pdu_test.go
+++ b/pkg/module/pdu/pdu_test.go
@@ -1,0 +1,242 @@
+// Copyright 2024 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pdu
+
+import (
+	"testing"
+)
+
+func TestParseOutletStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		outlet   int
+		xmlBody  string
+		expected string
+		err      bool
+	}{
+		{
+			name:   "outlet 0 on",
+			outlet: 0,
+			xmlBody: `<response>
+<outletStat0>on</outletStat0>
+<outletStat1>off</outletStat1>
+</response>`,
+			expected: "on",
+			err:      false,
+		},
+		{
+			name:   "outlet 1 off",
+			outlet: 1,
+			xmlBody: `<response>
+<outletStat0>on</outletStat0>
+<outletStat1>off</outletStat1>
+</response>`,
+			expected: "off",
+			err:      false,
+		},
+		{
+			name:   "outlet 6 on with whitespace",
+			outlet: 6,
+			xmlBody: `<response>
+<outletStat6>  on  </outletStat6>
+</response>`,
+			expected: "on",
+			err:      false,
+		},
+		{
+			name:   "outlet not found",
+			outlet: 5,
+			xmlBody: `<response>
+<outletStat0>on</outletStat0>
+<outletStat1>off</outletStat1>
+</response>`,
+			expected: "",
+			err:      true,
+		},
+		{
+			name:   "malformed XML - missing end tag",
+			outlet: 0,
+			xmlBody: `<response>
+<outletStat0>on
+</response>`,
+			expected: "",
+			err:      true,
+		},
+		{
+			name:   "unexpected outlet state",
+			outlet: 0,
+			xmlBody: `<response>
+<outletStat0>unknown</outletStat0>
+</response>`,
+			expected: "",
+			err:      true,
+		},
+		{
+			name:   "real PDU response example",
+			outlet: 6,
+			xmlBody: `<response>
+<cur0>0.2</cur0>
+<stat0>normal</stat0>
+<curBan>0.2</curBan>
+<tempBan>30</tempBan>
+<humBan>31</humBan>
+<statBan>normal</statBan>
+<outletStat0>on</outletStat0>
+<outletStat1>on</outletStat1>
+<outletStat2>on</outletStat2>
+<outletStat3>on</outletStat3>
+<outletStat4>on</outletStat4>
+<outletStat5>on</outletStat5>
+<outletStat6>on</outletStat6>
+<outletStat7>off</outletStat7>
+<userVerifyRes>0</userVerifyRes>
+</response>`,
+			expected: "on",
+			err:      false,
+		},
+		{
+			name:     "empty XML",
+			outlet:   0,
+			xmlBody:  "",
+			expected: "",
+			err:      true,
+		},
+		{
+			name:   "outlet number out of range",
+			outlet: 99,
+			xmlBody: `<response>
+<outletStat0>on</outletStat0>
+</response>`,
+			expected: "",
+			err:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &PDU{
+				Outlet: tt.outlet,
+			}
+
+			result, err := p.parseOutletStatus([]byte(tt.xmlBody))
+
+			if tt.err {
+				if err == nil {
+					t.Errorf("parseOutletStatus() expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("parseOutletStatus() unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("parseOutletStatus() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseOp(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected op
+		err      bool
+	}{
+		{
+			name:     "on command",
+			input:    "on",
+			expected: opOn,
+			err:      false,
+		},
+		{
+			name:     "off command",
+			input:    "off",
+			expected: opOff,
+			err:      false,
+		},
+		{
+			name:     "toggle command",
+			input:    "toggle",
+			expected: opToggle,
+			err:      false,
+		},
+		{
+			name:     "invalid command",
+			input:    "invalid",
+			expected: "",
+			err:      true,
+		},
+		{
+			name:     "empty command",
+			input:    "",
+			expected: "",
+			err:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseOp(tt.input)
+
+			if tt.err {
+				if err == nil {
+					t.Errorf("parseOp() expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("parseOp() unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("parseOp() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestOpString(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       op
+		expected string
+	}{
+		{
+			name:     "opOn",
+			op:       opOn,
+			expected: "0",
+		},
+		{
+			name:     "opOff",
+			op:       opOff,
+			expected: "1",
+		},
+		{
+			name:     "opToggle",
+			op:       opToggle,
+			expected: "2",
+		},
+		{
+			name:     "invalid op",
+			op:       op("invalid"),
+			expected: "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.op.String()
+			if result != tt.expected {
+				t.Errorf("op.String() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This module adds support for controlling a Power Distribution Unit (PDU) outlet over HTTP using basic commands: on, off, toggle, and status. The module communicates with a PDU that exposes an HTTP interface with XML responses.

Supported features:
- Power control: turn outlet on, off, or toggle state
- Status query: fetch and parse current outlet state from status.xml
- Basic authentication support for protected endpoints

This module integrates with dutctl's modular interface and logs activity via the standard Session output.

Note: currently supports a single outlet (outlet0).

- [x] Tested with Intellinet hardware

Closes #8 