### PR TITLE
Fix golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -158,6 +158,7 @@ linters-settings:
       - stdlib
       - generic
       - "Module"
+      - "gpio"
 
   lll:
     line-length: 140

--- a/pkg/module/gpio/gpio.go
+++ b/pkg/module/gpio/gpio.go
@@ -49,8 +49,6 @@ type backendParser func(name string) gpio
 // backendFromOption is the default [backendParser] function.
 // Currently only "devmem" is supported.
 // If the name is not recognized, the 'devmem' is used as a fallback.
-//
-//nolint:ireturn
 func backendFromOption(name string) gpio {
 	switch name {
 	case "devmem":


### PR DESCRIPTION
Somehow the linter was complaining about both:
- //nolint directive unused
- returning a interface if no //nolint was set

Cleaning up //nolint comments and adapt golangci.yaml in general will be considered separately.