### PR TITLE
ci: list dependency update in CHANGELOG

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,8 +37,7 @@
         },
         {
             "type": "chore",
-            "section": "Chore",
-            "hidden": true
+            "section": "Other Work"
         },
         {
             "type": "revert",


### PR DESCRIPTION
This makes chore-commits listed in the "Other Work" section in the CHANGELOG, thus dependency updates are made visible when cutting a release.