### PR TITLE
docs: Fix typos, spelling and tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 
 # DUT Control: Unified Device Management for Open Firmware Development
 
-dutctl stands for "Device-under-Test Control" and is an open-source command-line utility and service ecosystem for managing development and test devices in firmware environments. By providing a unified interface to interact with boards and test fixtures across platforms, dutctl eliminates the fragmentation of device management tools that has long plagued firmware workflows. The project features remote device control, command streaming, multi-architecture testing, and a flexible plugin architecture for extensibility.
+_dutctl_ stands for "Device-under-Test Control" and is an open-source command-line utility and service ecosystem for managing development and test devices in firmware environments. By providing a unified interface to interact with boards and test fixtures across platforms, _dutctl_ eliminates the fragmentation of device management tools that has long plagued firmware workflows. The project features remote device control, command streaming, multi-architecture testing, and a flexible plugin architecture for extensibility.
 
-[![GitHub Release](https://img.shields.io/github/v/release/BlindspotSoftware/dutctl?include_prereleases&sort=semver&display_name=release)](https://github.com/BlindspotSoftware/dutctl/releases) ![Build Status](https://img.shields.io/github/actions/workflow/status/BlindspotSoftware/dutctl/go.yml?branch=main)[![License](https://img.shields.io/github/license/BlindspotSoftware/dutctl)](https://github.com/BlindspotSoftware/dutctl/blob/main/LICENSE) [![Go Report Card](https://goreportcard.com/badge/github.com/BlindspotSoftware/dutctl)](https://goreportcard.com/report/github.com/BlindspotSoftware/dutctl)
+[![GitHub Release](https://img.shields.io/github/v/release/BlindspotSoftware/dutctl?include_prereleases&sort=semver&display_name=release)](https://github.com/BlindspotSoftware/dutctl/releases)
+![Build Status](https://img.shields.io/github/actions/workflow/status/BlindspotSoftware/dutctl/go.yml?branch=main)
+[![License](https://img.shields.io/github/license/BlindspotSoftware/dutctl)](https://github.com/BlindspotSoftware/dutctl/blob/main/LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/github.com/BlindspotSoftware/dutctl)](https://goreportcard.com/report/github.com/BlindspotSoftware/dutctl)
 
 
 ---
 
 ## Overview
 
-dutctl is designed for firmware developers, QA teams, and CI/CD pipelines, simplifying complex device interactions through intuitive commands, easy configuration and scalability. The platform supports both local and remote device management through its agent-server architecture, enabling efficient collaboration in distributed teams. 
+_dutctl_ is designed for firmware developers, QA teams, and CI/CD pipelines, simplifying complex device interactions 
+through intuitive commands, easy configuration, and scalability. The platform supports both local and remote device 
+management through its agent-server architecture, enabling efficient collaboration in distributed teams. 
 
 ```
 ┌────────────┐        ┌────────────┐        ┌───────────┐
@@ -30,12 +35,13 @@ Key features include:
 For detailed information on the system architecture, see the [Documentation](./docs/README.md).
 
 | Supported Client OS | Recommended DUT Agent Hardware |
-| ------------------- | ------------------------------ |
+|---------------------|--------------------------------|
 | Linux               | RaspberryPi 4                  |
 
 ## Getting Started
 
-Download the [latest release](https://github.com/BlindspotSoftware/dutctl/releases) or use the [go toolchain](https://go.dev/) to install the components: `go install github.com/BlindspotSoftware/dutctl/cmds/dutctl@latest github.com/BlindspotSoftware/dutctl/cmds/dutagent@latest`
+Download the [latest release](https://github.com/BlindspotSoftware/dutctl/releases) or use the 
+[go toolchain](https://go.dev/) to install the components: `go install github.com/BlindspotSoftware/dutctl/cmds/dutctl@latest github.com/BlindspotSoftware/dutctl/cmds/dutagent@latest`
 
 
 1. **Start the DUT Agent**
@@ -58,43 +64,47 @@ Download the [latest release](https://github.com/BlindspotSoftware/dutctl/releas
 
 ## Public Interfaces
 
-With the current pre-release state, we are working towards a stable and backwards compatible v1. Therefore we identified the following public interfaces, which will become stable with the first major release:
+With the current pre-release state, we are working towards a stable and backwards compatible v1. Therefore, we
+identified the following public interfaces, which will become stable with the first major release:
 
-1) The command line interfaces of the project's apps
-   - The client, see `dutctl -h`
-   - The agent, see `dutagent -h`
-   - The relay server (upcoming, currently PoC)
+1) Command-line interfaces for the project's applications:
+   - DUT Client - see `dutctl -h`
+   - DUT Agent - see `dutagent -h`
+   - DUT Server (in development, currently at proof-of-concept stage)
 
-2) The configuring the agents
-   - [YAML specification](./docs/dutagent-config.md)
+2) DUT Agent configuration:
+   - See the [YAML specification](./docs/dutagent-config.md)
 
-3) The RPC communication protocol for calling agents
-   - [Protobuf definitions](./protobuf/dutctl/v1/dutctl.proto)
+3) RPC communication protocol for interacting with agents:
+   - See the [Protobuf definitions](./protobuf/dutctl/v1/dutctl.proto)
 
 ## Individual Setup
 
-If you are ready to get your hands dirty, hook up your DUT to a singel board computer (we recomend RPi4) and launch the DUT agent on it. Below you can find the currently supported modules with example configurations. Read on [here](./docs/dutagent-config.md), to learn how you can adapt the agent's configuration to your needs
+If you are ready to get your hands dirty, hook up your DUT to a single board computer (we recommend RPi4) and launch the
+DUT agent on it. Below you can find the currently supported modules with example configurations. Read on 
+[here](./docs/dutagent-config.md), to learn how you can adapt the agent's configuration to your needs
 
-| Modules                                                           | Status                   |
-| ----------------------------------------------------------------- | ------------------------ |
-| [GPIO Button](./pkg/module/gpio/README.md)                        | :white_check_mark:       |
-| [GPIO Switch](./pkg/module/gpio/README.md)                        | :white_check_mark:       |
-| [IPMI Power Control](./pkg/module/gpio/README.md)                 | :white_check_mark:       |
-| [Power Distribution Unit, Intellinet](./pkg/module/pdu/README.md) | :white_check_mark:       |
-| Power Distribution Unit, Delock                                   | :hourglass_flowing_sand: |
-| [SPI Flasher, flashrom](./pkg/module/flash/README.md)             | :white_check_mark:       |
-| SPI Flasher, flashprog                                            | :hourglass_flowing_sand: |
-| [Serial Console](./pkg/module/serial/README.md)                   | :white_check_mark:       |
-| [Shell Execution](./pkg/module/shell/README.md)                   | :white_check_mark:       |
-| [Secure Shell (SSH)](./pkg/module/ssh/README.md)                  | :white_check_mark:       |
+| Modules                                                            | Status                   |
+|--------------------------------------------------------------------|--------------------------|
+| [GPIO Button](./pkg/module/gpio/README.md)                         | :white_check_mark:       |
+| [GPIO Switch](./pkg/module/gpio/README.md)                         | :white_check_mark:       |
+| [IPMI Power Control](./pkg/module/gpio/README.md)                  | :white_check_mark:       |
+| [Power Distribution Unit (Intellinet)](./pkg/module/pdu/README.md) | :white_check_mark:       |
+| Power Distribution Unit (Delock)                                   | :hourglass_flowing_sand: |
+| [SPI Flasher (flashrom)](./pkg/module/flash/README.md)             | :white_check_mark:       |
+| SPI Flasher (flashprog)                                            | :hourglass_flowing_sand: |
+| [Serial Console](./pkg/module/serial/README.md)                    | :white_check_mark:       |
+| [Shell Execution](./pkg/module/shell/README.md)                    | :white_check_mark:       |
+| [Secure Shell (SSH)](./pkg/module/ssh/README.md)                   | :white_check_mark:       |
 
 
 If you have special needs, you can extend the system with your own modules. Read about the [module plugin system](./docs/module_guide.md).
 
 ## DUT Control at Scale
 
-If you have multiple devices hooked up to multiple agents at differen location, you may wounder if you can handle them without connecting to the respective agents every time.
-[DUT server]((./cmds/exp/dutserver/README.md)) is there for the rescue: It is at proof-of-concept state right now, but you can already [try it out](./cmds/exp/dutserver/README.md).
+If you have multiple devices hooked up to multiple agents at different locations, you may wonder if you can handle them
+without connecting to the respective agents every time. [DUT server](./cmds/exp/dutserver/README.md) is there for the
+rescue: It is at proof-of-concept state right now, but you can already [try it out](./cmds/exp/dutserver/README.md).
 
 ## Contributing
 
@@ -103,9 +113,11 @@ Contributions are welcome! Please see our [Contributing Guide](./CONTRIBUTING.md
 
 ---
 
-This project is supported by the [NLnet Foundation](https://nlnet.nl/) and the Next Generation Internet (NGI) Zero Commons Fund. The NGI0 Commons Fund is made possible with financial support from the European Commission's [Next Generation Internet](https://ngi.eu/) programme.
+This project is supported by the [NLnet Foundation](https://nlnet.nl/) and the Next Generation Internet (NGI) Zero
+Commons Fund. The NGI0 Commons Fund is made possible with financial support from the European Commission's
+[Next Generation Internet](https://ngi.eu/) program.
 
-|                                                            |                  |               |
-| -------------------------------------------------------------- | ------------------------ | ---- |
-| ![nlnet](./assets/nlnet.png) | ![European Union](./assets/EU.png) | ![NGI0](./assets/NGI0.png)|
+|                              |                                    |                            |
+|------------------------------|------------------------------------|----------------------------|
+| ![nlnet](./assets/nlnet.png) | ![European Union](./assets/EU.png) | ![NGI0](./assets/NGI0.png) |
 

--- a/cmds/exp/dutserver/README.md
+++ b/cmds/exp/dutserver/README.md
@@ -14,7 +14,7 @@ The DUT Server acts as a centralized proxy for multiple Device Under Test (DUT) 
 └─────────┘      └───────────┘      └─────────┘      └────────┘
 ```
 
-The main goal of the DUT server is to provide a single access point for all registered devices, regardless of their physical location i.e. regardless of the DUT agent devices are connected to.
+The main goal of the DUT Server is to provide a single access point for all registered devices, regardless of their physical location, i.e., regardless of the DUT Agent devices are connected to.
 
 ## Implemented Features
 
@@ -35,7 +35,7 @@ As a proof of concept, this implementation has several limitations that would ne
 
 ## Demo
 
-In the project root dir, make sure client, agent and server are built:
+In the project root dir, make sure the DUT Client, DUT agent and DUT Server are built:
 ```
 go build ./cmds/dutctl
 go build ./cmds/dutagent
@@ -44,7 +44,7 @@ go build ./cmds/exp/dutserver
 Open up four terminal sessions referred to as `T1`, `T2`, `T3`, `T4`,
 
 ### Starting the Server
-In `T1` start the DUT server with default settings:
+In `T1` start the DUT Server with default settings:
 
 ```bash
 # Start the DUT Server locally on default port (1024)
@@ -53,7 +53,7 @@ In `T1` start the DUT server with default settings:
 
 ### Registering Devices
 
-Start a first agent in `T3` using a basic example configuration with one device and set the optional `-server` flag to register with the running DUT server:
+Start a first agent in `T3` using a basic example configuration with one device and set the optional `-server` flag to register with the running DUT Server:
 
 ```bash
 # Configure the agent to connect to the server
@@ -61,7 +61,7 @@ Start a first agent in `T3` using a basic example configuration with one device 
 
 ```
 
-In `T4` start a secound agent with different port and another basic example configuration with another device:
+In `T4` start a second agent with different port and another basic example configuration with another device:
 
 ```bash
 # Configure the agent to connect to the server
@@ -71,7 +71,7 @@ In `T4` start a secound agent with different port and another basic example conf
 
 ### Connecting with a Client
 
-Play around with the DUT client in `T2`
+Play around with the DUT Client in `T2`
 
 ```bash
 # List available devices using the default address localhost:1024 which is the DUT server
@@ -84,5 +84,5 @@ Play around with the DUT client in `T2`
 ./dutctl device2 repeat
 ```
 
-The complete functionality of the client is available via the DUT server, see `./dutctl -h`
+The complete functionality of the client is available via the DUT Server, see `./dutctl -h`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,51 +1,77 @@
 # System Overview
 
-DUTCTL is a decentralized client-agent architecture as shown here:
+DUT Control (DUTCTL) is a decentralized client-agent architecture as shown here:
 
 ![dutctl_server_agent](https://github.com/BlindspotSoftware/dutctl/assets/14163031/c16b0bde-4fb1-4a4e-8faf-ff63e24d8ac8)
 
-Multiple Devices-Under-Test (DUTs) can be connected and physically wired to one DUT Agent (DA) which performs the hardware interaction. If the system scales, multiple DUT Agents can be used. DUT Controll are clients that connect (remotely) to a DUT Agent and build the system's user interface. 
+Multiple Devices-Under-Test (DUTs) can be connected and physically wired to one DUT Agent (DA) which performs the
+hardware interaction. If the system scales, multiple DUT Agents can be used. Users control DUTs through DUT Client,
+which connects (remotely) to a DUT Agent and builds the system's user interface. 
 
-As a later feature there will be DUT Server which abstracts the DUT to DUT Agent connections and improves the usability in larger systems. From the DUT Controll client side there is no difference between talking to a DUT Agent or the DUT Server in terms of controlling the hardware.
+In a future release, there will be DUT Server, which abstracts the DUT Client to DUT Agent connections and improves the
+usability in larger systems. From the DUT Client side, there is no difference between talking to a DUT Agent or the DUT
+Server in terms of controlling the hardware.
 
 ## Device-Under-Test (DUT)
 The machine or hardware you want to operate.
 
-## DUT Control (dutctl)
-This is the actual application running on the user's machine. It provides a command line interface to issue task. This client app thought, has no knowledge about the connected DUT's and their available controll operations. Those information is provided by the agent on request. 
+## DUT Client (dutctl)
+This is the actual application running on the user's machine. It provides a command line interface to issue a task.
+This client app, thought, has no knowledge about the connected DUT's and their available control operations. That
+information is provided by the agent on request. 
 
 ## DUT Agent (DA)
-The DUT Agend is a service designed to run on a single board computer, which can handle the wiring to the DUT (power control, reset, flasher, serial console, etc.) The specifics and supported operation for the wired DUTs are feed to the DUT Agent via a [configuration file](./dutagent-config.md)
+The DUT Agent is a service designed to run on a single board computer, which can handle the wiring to the DUT (power
+control, reset, flasher, serial console, etc.) The specifics and supported operation for the wired DUTs are feed to the
+DUT Agent via a [configuration file](./dutagent-config.md)
 
 ## DUT Server
-The DUT Server is designed to let the project scale. It's basic purpose is to maintain a table with the DUT to DUT Agent relations. It's interface towards a DUT Control client is the same as the the one from a DUT Agent. This way there is no difference from the client side to which instance to talk to. Additionally the DUT Server could expose further interfaces like a REST API to observe the fleet of DUTs. 
+The DUT Server is designed to let the project scale. Its basic purpose is to maintain a table with the DUT to DUT Agent
+relations. Its interface towards a DUT Client is the same as the one from a DUT Agent. This way there is no difference
+from the client side to which instance to talk to. Additionally, the DUT Server could expose further interfaces like a
+REST API to observe the fleet of DUTs. 
 
 # Communication Design
 
-The distributed entities of the DUT Control system comunicate via Remote Proceture Calls (RPCs), which are defined in `protobuf/dutctl/v1/dutctl.proto`. The communication is always initiated by the client and there are three calls defined in the RPC service, that a client can issue to the agent: 
-1) List, to list the the available connected devices 
+The distributed entities of the DUT Control system communicate via Remote Procedure Calls (RPCs), which are defined in
+`protobuf/dutctl/v1/dutctl.proto`. The communication is always initiated by the client, and there are three calls 
+defined in the RPC service that a client can issue to the agent: 
+1) List, to list the available connected devices 
 2) Commands, to learn about the available commands of a given device
 3) Run, to execute a command on a device
 
-While the 1) and 2) are quite straight forward, the Run-RPC is a bidirectional stream, where both, the client and the agent are sending multiple messages until the end of the command execution.
-According to the protobuf definition, during a Run-RPC stream the client and the agent are sending RunRequests and RunResponses, respectively. This messages are abstractions for different types of messages being sent between client and agent and the following convention applies:
+While the 1) and 2) are quite straight forward, the Run-RPC is a bidirectional stream, where both the client and the
+agent are sending multiple messages until the end of the command execution. According to the protobuf definition, during
+a Run-RPC stream, the client and the agent are sending RunRequests and RunResponses, respectively. These messages are
+abstractions for different types of messages being sent between client and agent, and the following convention applies:
 
-The first RunRequest sent by the client must always be a Command message. 
-Depending on the module implementation of the executed command, there are the following scenarios for the further communication during the Run-RPC stream: 
+The first RunRequest sent by the client must always be a Command message. Depending on the module implementation of the
+executed command, there are the following scenarios for the further communication during the Run-RPC stream: 
 
 ![print-msg](https://github.com/user-attachments/assets/e2f0b21e-3048-44d4-81e1-aab58017c38d)
 
-**Print**: After the initial RunRequest with a Command message by the client, the agent sends one or many RunResponses being Print messages. This type of messages are usually good for status updates of basic commands, which do not require further interaction or input. By convention Print messages should not be mixed with Console messages.
+**Print**: After the initial RunRequest with a Command message by the client, the agent sends one or many RunResponses
+being Print messages. This type of messages is usually good for status updates of basic commands, which do not require
+further interaction or input. By convention, Print messages should not be mixed with Console messages.
 
 ![Console-msg](https://github.com/user-attachments/assets/e1a946bf-3482-41c1-9a01-5df5d5318fc7)
 
-**Console**: After the initial RunRequest with a Command message by the client, the agent sends one RunResponses being a Console message. From this time on until the end of the command execution, standard input from the client is redirected to the agent and standard output and standard error from the agent to the client. This way a remote console is realized, which enables interactive command execution. By convention, Console messages should not be mixed with Print messages.
+**Console**: After the initial RunRequest with a Command message by the client, the agent sends one RunResponses being
+a Console message. From this time on until the end of the command execution, standard input from the client is
+redirected to the agent and standard output and standard error from the agent to the client. This way a remote console
+is realized, which enables interactive command execution. By convention, Console messages should not be mixed with Print
+messages.
 
 ![FileDownload-msg](https://github.com/user-attachments/assets/2e6d75e6-02b0-43e1-875f-3e7634b6b147)
 
-**File download to the client**: After the initial RunRequest with a Command message by the client, for commands producing any artifacts, these can be downloaded to the client, with a RunResponse being a File message. Downloads can happen multiple times and can be mixed with Print messages and Console messages and file uploads.
+**File download to the client**: After the initial RunRequest with a Command message by the client, for commands
+producing any artifacts, these can be downloaded to the client, with a RunResponse being a File message. Downloads can
+happen multiple times and can be mixed with Print messages and Console messages and file uploads.
 
 ![FileUpload-msg](https://github.com/user-attachments/assets/1a12204b-58b1-4b05-88ec-c8a3ba3f2b6a)
 
-**File Upload to the agent**: After the initial RunRequest with a Command message by the client, for commands needing any artifacts, these can be uploaded to the client, with a RunResponse being a FileRequest message and the client answering with a RunRequest being a File message. Uploads can happen multiple times and can be mixed with Print messages and Console messages and file downloads.
+**File Upload to the agent**: After the initial RunRequest with a Command message by the client, for commands needing
+any artifacts, these can be uploaded to the client, with a RunResponse being a FileRequest message and the client
+answering with a RunRequest being a File message. Uploads can happen multiple times and can be mixed with Print
+messages and Console messages and file downloads.
 

--- a/docs/dutagent-config.md
+++ b/docs/dutagent-config.md
@@ -2,51 +2,51 @@
 
 The _DUT Agent_ is configured by a YAML configuration file.
 
-The configuration mainly consists of a list of devices connected to an agent and and a list of the _Commands_ available
-for those devices. Commands are meant to be the hig level tasks you want to perform on the device e.g 
-"Flash the firmware with the given image". To achieve this high level task, commands can be build up of one or multiple
+The configuration mainly consists of a list of devices connected to an agent and a list of the _Commands_ available
+for those devices. Commands are meant to be the high-level tasks you want to perform on the device, e.g. 
+"Flash the firmware with the given image." To achieve this high-level task, commands can be built up of one or multiple
 _Modules_. Modules represent the basic operations and represent the actual implementation for the hardware interaction.
-The implementation of a Module determines its capabilities and also exposes information on how to use und configure it.  
+The implementation of a Module determines its capabilities and also exposes information on how to use and configure it.  
 
-The DUT Control project offers a collection of Module implementation but also allows for easy integration of [custom modules](./module_guide.md). 
-Often a _Command_ can consist of only one _Module_ to get the job done, e.g. power cycle the device. But in some cases
-like the flash example mentioned earlier, eventually it is mandetory to toggle some GPIOs befor doing the actual SPI flash
-operation. In this case the command is build up of a Module dealing with GPIO manipulation and a Module performing a
-flash write with a specific programmer. See the 2nd device in the [example](#example-config-file) down below on how this
+The DUT Control project offers a collection of Module implementations but also allows for easy integration of [custom modules](./module_guide.md). 
+Often a _Command_ can consist of only one _Module_ to get the job done, e.g., power cycles the device. But in some cases
+like the flash example mentioned earlier, eventually it is mandatory to toggle some GPIOs before doing the actual SPI flash
+operation. In this case the command is built up of a Module dealing with GPIO manipulation and a Module performing a
+flash writing with a specific programmer. See the second device in the [example](#example-config-file) down below on what this
 could look like.
 
 ### DUT Agent Configuration Schema
 
-| Attribute | Type | Default | Description | Mandatory |
-| --- | --- | --- | --- | --- |
-| version | string |  | Version of this config schema | yes |
-| devices | [] [Device](#Device) |  | List of dives-under-test (DUTs) connected to this agent | yes |
+| Attribute | Type                 | Default | Description                                             | Mandatory |
+|-----------|----------------------|---------|---------------------------------------------------------|-----------|
+| version   | string               |         | Version of this config schema                           | yes       |
+| devices   | [] [Device](#Device) |         | List of dives-under-test (DUTs) connected to this agent | yes       |
 
 ### Device
 
-| Attribute | Type | Default | Description | Mandatory |
-| --- | --- | --- | --- | --- |
-| description | string |  | Device description. May be used to state technical details which are important when working with this DUT. | no |
-| commands | [] [Command](#Commands) |  | List of available device commands. Commands are the hig level tasks that can be performed on the device. | no |
+| Attribute   | Type                    | Default | Description                                                                                                | Mandatory |
+|-------------|-------------------------|---------|------------------------------------------------------------------------------------------------------------|-----------|
+| description | string                  |         | Device description. May be used to state technical details which are important when working with this DUT. | no        |
+| commands    | [] [Command](#Commands) |         | List of available device commands. Commands are the hig level tasks that can be performed on the device.   | no        |
 
 ### Commands
 
-| Attribute | Type | Default | Description | Mandatory |
-| --- | --- | --- | --- | --- |
-| description | string |  | Command description | no |
-| Modules | [] [Module](#Module) |  | A command may be composed of multiple steps to achieve its purpose. The list of modules represent these steps.The order of this list is important, though. Exactly one of the modules must be set as the main module. All arguments to a command are passed to its main module. The main modules usage information is also used as the command help text. If a Command is composed of only one module, this module becomes the main module implicitly.| yes |
+| Attribute   | Type                 | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                                                            | Mandatory |
+|-------------|----------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| description | string               |         | Command description                                                                                                                                                                                                                                                                                                                                                                                                                                    | no        |
+| Modules     | [] [Module](#Module) |         | A command may be composed of multiple steps to achieve its purpose. The list of modules represent these steps.The order of this list is important, though. Exactly one of the modules must be set as the main module. All arguments to a command are passed to its main module. The main modules usage information is also used as the command help text. If a Command is composed of only one module, this module becomes the main module implicitly. | yes       |
 
 ### Module
 
-| Attribute | Type | Default | Description | Mandatory |
-| --- | --- | --- | --- | --- |
-| module | string |  | The module's name also serves as its identifier and must be unique. | yes |
-| main | bool | false | All arguments to a command are passed to its main module. The main modules usage information is also used as the command help text. Can be omitted, if only one modules exists within the command.| exactly once per command |
-| args | []string | nil | If a module is **not** an commands main module, it does not get any arguments passed at runtime, instead arguments can be passed here.| no, only applies if `main` is set |
-| options | map[string]any |  | A module can be configured via key-value pairs. The type of the value is generic and depends on the implementation of the module.| yes |
+| Attribute | Type           | Default | Description                                                                                                                                                                                        | Mandatory                         |
+|-----------|----------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
+| module    | string         |         | The module's name also serves as its identifier and must be unique.                                                                                                                                | yes                               |
+| main      | bool           | false   | All arguments to a command are passed to its main module. The main modules usage information is also used as the command help text. Can be omitted, if only one modules exists within the command. | exactly once per command          |
+| args      | []string       | nil     | If a module is **not** an commands main module, it does not get any arguments passed at runtime, instead arguments can be passed here.                                                             | no, only applies if `main` is set |
+| options   | map[string]any |         | A module can be configured via key-value pairs. The type of the value is generic and depends on the implementation of the module.                                                                  | yes                               |
 
 > [!IMPORTANT]  
-> Refer to option keys of a module in all-lowercase representation of the the modules exported fields.
+> Refer to option keys of a module in all-lowercase representation of the modules exported fields.
 > See the respective module's documentation for details.
 
 ### Example config file

--- a/docs/module_guide.md
+++ b/docs/module_guide.md
@@ -1,12 +1,14 @@
 # Module Plug-In System
 
-In DUT Control, modules represent the implementation of actions to be performed on a device. One or more Modules make up a command that can be issued to a device. The implementation of a Module determines its capabilities and also exposes information on how to use and configure it.
+In DUT Control, modules represent the implementation of actions to be performed on a device. One or more Modules make
+up a command that can be issued to a device. The implementation of a Module determines its capabilities and also exposes
+information on how to use and configure it.
 
 The DUT Control project is designed for easy integration of new modules via a plug-in system.
 
 > [!NOTE] 
-> The modules generally available at a running dutagent instance are set at compile time of dutagent. 
-> Which Modules are use with certain devices is controlled via the dutagent configuration, when starting dutagent.
+> The modules generally available at a running dutagent instance are set at the compile time of dutagent. 
+> Which Modules are used with certain devices is controlled via the dutagent configuration when starting dutagent.
 
 ## The Module interface
 Modules must implement the following interface:
@@ -19,13 +21,15 @@ type Module interface {
 }
 ```
 See [`pkg/module/module.go`](../pkg/module/module.go) for further information on the set of functions. 
-With the _Session_ provided to the module, it is able to interact with the client during execution (status messages, request input, file transfer, etc.).
+With the _Session_ provided to the module, it is able to interact with the client during execution (status messages,
+request input, file transfer, etc.).
 
 ## Registration
 
 New modules go under `pkg/modules'. 
 
-To register a module for use in dutagend, modules must call `module.Register()` and provide its name and a constructor. By convention, this is done in the module's `init()` function. E.g:
+To register a module for use in _dutagent_, modules must call `module.Register()` and provide its name and a
+constructor. By convention, this is done in the module's `init()` function. E.g.:
 ```go
 func init() {
 	module.Register(module.Info{
@@ -34,18 +38,22 @@ func init() {
 	})
 }
 ```
-`ID` is the module's unique identifier. This string is used in the [dutagent configuration](./dutagent-config.md) to refer to this module implementation. 
+`ID` is the module's unique identifier. This string is used in the [_dutagent_ configuration](./dutagent-config.md) to refer to this
+module implementation. 
 
 `New` is a function to instantiate an instance of the module. Usually it can be as simple as shown above. 
-Note that initial setup code can be placed in the `Init()` function of the module interface, which supports error checking and should be preferred over the constructor for most setup code. 
+Note that initial setup code can be placed in the `Init()` function of the module interface, which supports error
+checking and should be preferred over the constructor for most setup code. 
 
-With this in place, the dutagent can use modules by using anonymous imports, e.g.:
+With this in place, the _dutagent_ can use modules by using anonymous imports, e.g.:
 ```go
 _ "github.com/BlindspotSoftware/dutctl/pkg/module/dummy"
 ```
 
 ## Configuration
-A module can be dynamically configured when starting a dutagent using the options map in the [dutagent configuration](./dutagent-config.md#module). A module must be of type `struct' and have the options as fields. The parser will set the struct fields to match the map keys.
+A module can be dynamically configured when starting a _dutagent_ using the option map in the
+[_dutagent_ configuration](./dutagent-config.md#module). A module must be of type `struct` and have the options as
+fields. The parser will set the struct fields to match the map keys.
 
 For example, a module like the one below, registered with `ID` = `"my-module"`.
 ```go
@@ -53,7 +61,7 @@ type MyModule struct {
 	Foo int    
 }
 ```
-can be configured with:
+It can be configured with:
 ```yaml
 ---
 version: 0
@@ -70,8 +78,7 @@ devices:
 ```
 > [!IMPORTANT]  
 > It is imperative that the module's documentation and Help() function provide a good explanation of its options.
-> The option map in the configuration file is generic (string -> any type), so it is important that the user knows what values are expected.
-
+> The option map in the configuration file is generic (string → any type), so it is important that the user knows what
+> values are expected.
 
 The [project's dummy modules](../pkg/module/dummy/dummy_status.go) show all the details of a complete implementation.
-

--- a/pkg/module/flash/README.md
+++ b/pkg/module/flash/README.md
@@ -13,14 +13,14 @@ For write operation, <image> is the local filepath to the image at the client.
 
 ```
 
-This module is a wrapper around a flash software on the dutagent. At the moment only _flashrom_ is supported.
-Other software will be configurable in this module later. The flasher software must be installed on the dutagent and
-a suitable flasher hardware must be hooked up to the DUT. Functionality is tested with DediProg programmers.
+This module is a wrapper around flash-software on the _dutagent_. At the moment only _flashrom_ is supported.
+Other software will be configurable in this module later. The flasher software must be installed on the _dutagent_, and
+ suitable flasher hardware must be hooked up to the DUT. Functionality is tested with DediProg programmers.
 
 See [flash-example-cfg.yml](./flash-example-cfg.yml) for examples. 
 
 ## Configuration Options
 
-| Option | Value | Description
-|----------|--------|------------------------------------|
-| programmer | string | Name of the flasher hardware, that is used by the dutagent and attached to the DUT's SPI flash. |
+| Option     | Value  | Description                                                                                       |
+|------------|--------|---------------------------------------------------------------------------------------------------|
+| programmer | string | Name of the flasher hardware, that is used by the _dutagent_ and attached to the DUT's SPI flash. |

--- a/pkg/module/gpio/README.md
+++ b/pkg/module/gpio/README.md
@@ -8,7 +8,7 @@ and set by default. That is memory mapping `dev/mem` memory region and manipulat
 memory. 
 
 > [!IMPORTANT]  
-> It is the users responsibility to ensure that the used GPIO pin is not also used by other modules
+> It is the user's responsibility to ensure that the used GPIO pin is not also used by other modules
 > or otherwise occupied by the system.
 
 # Button
@@ -30,11 +30,11 @@ See [gpio-example-cfg.yml](./gpio-example-cfg.yml) for examples.
 
 ## Configuration Options
 
-| Option | Value | Description
-|----------|--------|------------------------------------|
-| pin | int | Raw BCM2835/BCM2711 pin number |
-| activelow | bool | If true, the idle state is high, and low when pressed. Default is false |
-| backend | string | For future use. Name of the backend to use. Default is "devmem" |
+| Option    | Value  | Description                                                             |
+|-----------|--------|-------------------------------------------------------------------------|
+| pin       | int    | Raw BCM2835/BCM2711 pin number                                          |
+| activelow | bool   | If true, the idle state is high, and low when pressed. Default is false |
+| backend   | string | For future use. Name of the backend to use. Default is "devmem"         |
 
 # Switch
 
@@ -48,15 +48,15 @@ The on, off and toggle commands control the state of the switch.
 If no argument is passed, the current state is printed.
 ```
 
-The Switch is initially turned off and by default off means 'low' and on means 'high'.
+The Switch is initially turned off and by default off means _low_ and on means _high_.
 
 See [gpio-example-cfg.yml](./gpio-example-cfg.yml) for examples.
 
 ## Configuration Options
 
-| Option | Value | Description
-|----------|--------|------------------------------------|
-| pin | int | Raw BCM2835/BCM2711 pin number |
-| initial | string | Initial state of the switch: "on" or "off" (case insensitive). Default and fallback is "off". |
-| activelow | bool | If true, the switch is active low (switch on means gpio pin low). Default is false.|
-| backend | string | For future use. Name of the backend to use. Default is "devmem" |
+| Option    | Value  | Description                                                                                   |
+|-----------|--------|-----------------------------------------------------------------------------------------------|
+| pin       | int    | Raw BCM2835/BCM2711 pin number                                                                |
+| initial   | string | Initial state of the switch: "on" or "off" (case insensitive). Default and fallback is "off". |
+| activelow | bool   | If true, the switch is active low (switch on means gpio pin low). Default is false.           |
+| backend   | string | For future use. Name of the backend to use. Default is "devmem"                               |

--- a/pkg/module/pdu/README.md
+++ b/pkg/module/pdu/README.md
@@ -1,6 +1,6 @@
 # PDU
 
-The **PDU** module provides basic power control of a Power Distribution Unit (PDU) via HTTP requests. It supports turning a power outlet on, off, toggling its state, and querying the current status.
+The _PDU_ module provides basic power control of a Power Distribution Unit (PDU) via HTTP requests. It supports turning a power outlet on, off, toggling its state, and querying the current status.
 
 **Note**: This module currently supports only Intellinet ATM PDUs.
 
@@ -15,7 +15,7 @@ pdu [on|off|toggle|status]
 ### Commands
 
 | Command  | Description                    |
-| -------- | ------------------------------ |
+|----------|--------------------------------|
 | `on`     | Power on the outlet            |
 | `off`    | Power off the outlet           |
 | `toggle` | Toggle the current power state |
@@ -28,7 +28,7 @@ See [pdu-example-cfg.yml](./pdu-example-cfg.yml) for examples.
 ## Configuration Options
 
 | Option     | Type   | Description                                    |
-| ---------- | ------ | ---------------------------------------------- |
+|------------|--------|------------------------------------------------|
 | `host`     | string | Base URL of the PDU (e.g. `10.0.0.5`)          |
 | `user`     | string | (Optional) Username for HTTP Basic Auth        |
 | `password` | string | (Optional) Password for HTTP Basic Auth        |

--- a/pkg/module/serial/README.md
+++ b/pkg/module/serial/README.md
@@ -2,7 +2,7 @@ The serial package provides a single module:
 
 # Serial
 
-This module establishes an serial connection to the DUT from the dutagent and  forwards the output.
+This module establishes a serial connection to the DUT from the _dutagent_ and forwards the output.
 
 ```
 ARGUMENTS:
@@ -18,15 +18,15 @@ Quote the regex if it contains spaces or special characters. E.g.: "(?i)hello\s+
 
 The syntax of the regular expressions accepted is the syntax accepted by RE2 and described at https://golang.org/s/re2syntax.
 
-The module is read-only at that time and does not support, sending bytes over the serial connection.
+The module is read-only at that time and does not support sending bytes over the serial connection.
 
 See [serial-example-cfg.yml](./serial-example-cfg.yml) for examples. 
 
 ## Configuration Options
 
-| Option | Value | Description
-|----------|--------|------------------------------------|
-| port | string | Hostname or IP address of the DUT |
-| baud | int | Port number of the SSH server on the DUT (default: 22) |
+| Option | Value  | Description                                            |
+|--------|--------|--------------------------------------------------------|
+| port   | string | Hostname or IP address of the DUT                      |
+| baud   | int    | Port number of the SSH server on the DUT (default: 22) |
 
 

--- a/pkg/module/shell/README.md
+++ b/pkg/module/shell/README.md
@@ -2,7 +2,7 @@ The _shell_ package provides a single module:
 
 # Shell
 
-This module executes a shell command on the DUT agent.
+This module executes a shell command on the DUT Agent.
 
 ```
 ARGUMENTS:
@@ -17,7 +17,7 @@ See [shell-example-cfg.yml](./shell-example-cfg.yml) for examples.
 
 ## Configuration Options
 
-| Option | Value | Description
-|----------|--------|------------------------------------|
-| path | string | Path is th path to the shell executable on the dutagent. Defaults to the system default shell  |
-| quiet | bool | Suppress forwarding stout, but not sterr |
+| Option | Value  | Description                                                                                   |
+|--------|--------|-----------------------------------------------------------------------------------------------|
+| path   | string | Path is th path to the shell executable on the dutagent. Defaults to the system default shell |
+| quiet  | bool   | Suppress forwarding to stdout, but not stderr                                                 |

--- a/pkg/module/ssh/README.md
+++ b/pkg/module/ssh/README.md
@@ -2,7 +2,7 @@ The _ssh_ package provides a single module:
 
 # SSH
 
-This module establishes an SSH connection to the DUT from the dutagent and executes a command.
+This module establishes an SSH connection to the DUT from the _dutagent_ and executes a command.
 
 ```
 ARGUMENTS:
@@ -21,12 +21,11 @@ See [ssh-example-cfg.yml](./ssh-example-cfg.yml) for examples.
 
 ## Configuration Options
 
-| Option | Value | Description
-|----------|--------|------------------------------------|
-| host | string | Hostname or IP address of the DUT |
-| port | int | Port number of the SSH server on the DUT (default: 22) |
-| user | string | Username for the SSH connection (default: "root") |
-| password | string | Password for the SSH connection |
-| privatekey | string | Path to the dutagent's private key file |
-| hostkey | string | Server's host key in the format [key_type] [base64_encoded_key] |
-
+| Option     | Value  | Description                                                     |
+|------------|--------|-----------------------------------------------------------------|
+| host       | string | Hostname or IP address of the DUT                               |
+| port       | int    | Port number of the SSH server on the DUT (default: 22)          |
+| user       | string | Username for the SSH connection (default: "root")               |
+| password   | string | Password for the SSH connection                                 |
+| privatekey | string | Path to the dutagent's private key file                         |
+| hostkey    | string | Server's host key in the format [key_type] [base64_encoded_key] |

--- a/protobuf/dutctl/v1/dutctl.proto
+++ b/protobuf/dutctl/v1/dutctl.proto
@@ -112,6 +112,6 @@ message RegisterRequest {
   string address = 2; // Address of the agent sending the request.
 }
 
-// RegisterResponse is sent by the relay server in response to a sucsessful RegisterRequest.
+// RegisterResponse is sent by the relay server in response to a successful RegisterRequest.
 // NOTE: This is an experimental service and may change in the future.
 message RegisterResponse {}


### PR DESCRIPTION
This patch focuses on fixing spelling and typos in the READMEs. It also caps the line length at around 120 characters. This was observed in some files and allows better readability in text form.

In some cases DUT Control was renamed to DUT Client where the text did not reference the whole project but the command line tool.