### PR TITLE
Make main module optional for commands

### DIFF
--- a/cmds/dutagent/rpc.go
+++ b/cmds/dutagent/rpc.go
@@ -72,7 +72,6 @@ func (a *rpcService) Commands(
 	return res, nil
 }
 
-//nolint:funlen
 func (a *rpcService) Details(
 	_ context.Context,
 	req *connect.Request[pb.DetailsRequest],
@@ -92,7 +91,7 @@ func (a *rpcService) Details(
 		return nil, e
 	}
 
-	_, cmd, err := a.devices.FindCmd(wantDev, wantCmd)
+	_, cmd, err := a.devices.FindCmd(wantDev, wantCmd, []string{})
 	if err != nil {
 		var code connect.Code
 		if errors.Is(err, dut.ErrDeviceNotFound) || errors.Is(err, dut.ErrCommandNotFound) {
@@ -109,25 +108,14 @@ func (a *rpcService) Details(
 		return nil, e
 	}
 
-	var (
-		helpStr   string
-		foundMain bool
-	)
+	var helpStr string
 
 	for _, module := range cmd.Modules {
 		if module.Config.Main {
-			foundMain = true
 			helpStr = module.Help()
+
+			break
 		}
-	}
-
-	if !foundMain {
-		e := connect.NewError(
-			connect.CodeInternal,
-			fmt.Errorf("no main module found for command %q at device %q", wantCmd, wantDev),
-		)
-
-		return nil, e
 	}
 
 	res := connect.NewResponse(&pb.DetailsResponse{

--- a/cmds/dutagent/runRPC.go
+++ b/cmds/dutagent/runRPC.go
@@ -95,11 +95,12 @@ func receiveCommandRPC(_ context.Context, args runCmdArgs) (runCmdArgs, fsm.Stat
 func findDUTCmd(_ context.Context, args runCmdArgs) (runCmdArgs, fsm.State[runCmdArgs], error) {
 	wantDev := args.cmdMsg.GetDevice()
 	wantCmd := args.cmdMsg.GetCommand()
+	cmdArgs := args.cmdMsg.GetArgs()
 
-	dev, cmd, err := args.deviceList.FindCmd(wantDev, wantCmd)
+	dev, cmd, err := args.deviceList.FindCmd(wantDev, wantCmd, cmdArgs)
 	if err != nil {
 		var code connect.Code
-		if errors.Is(err, dut.ErrDeviceNotFound) || errors.Is(err, dut.ErrCommandNotFound) {
+		if errors.Is(err, dut.ErrDeviceNotFound) || errors.Is(err, dut.ErrCommandNotFound) || errors.Is(err, dut.ErrNoMainForArgs) {
 			code = connect.CodeInvalidArgument
 		} else {
 			code = connect.CodeInternal

--- a/docs/dutagent-config.md
+++ b/docs/dutagent-config.md
@@ -3,7 +3,7 @@
 The _DUT Agent_ is configured by a YAML configuration file.
 
 The configuration mainly consists of a list of devices connected to an agent and a list of the _Commands_ available
-for those devices. Commands are meant to be the high-level tasks you want to perform on the device, e.g. 
+for those devices. Commands are meant to be the high-level tasks you want to perform on the device, e.g.
 "Flash the firmware with the given image." To achieve this high-level task, commands can be built up of one or multiple
 _Modules_. Modules represent the basic operations and represent the actual implementation for the hardware interaction.
 The implementation of a Module determines its capabilities and also exposes information on how to use and configure it.  
@@ -34,14 +34,14 @@ could look like.
 | Attribute   | Type                 | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                                                            | Mandatory |
 |-------------|----------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
 | description | string               |         | Command description                                                                                                                                                                                                                                                                                                                                                                                                                                    | no        |
-| Modules     | [] [Module](#Module) |         | A command may be composed of multiple steps to achieve its purpose. The list of modules represent these steps.The order of this list is important, though. Exactly one of the modules must be set as the main module. All arguments to a command are passed to its main module. The main modules usage information is also used as the command help text. If a Command is composed of only one module, this module becomes the main module implicitly. | yes       |
+| Modules     | [] [Module](#Module) |         | A command may be composed of multiple steps to achieve its purpose. The list of modules represent these steps. The order of this list is important. At most one module may be set as the main module. If a main module is present, all arguments to the command are passed to it, and its usage information is used as the command help text. | yes       |
 
 ### Module
 
 | Attribute | Type           | Default | Description                                                                                                                                                                                        | Mandatory                         |
 |-----------|----------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
 | module    | string         |         | The module's name also serves as its identifier and must be unique.                                                                                                                                | yes                               |
-| main      | bool           | false   | All arguments to a command are passed to its main module. The main modules usage information is also used as the command help text. Can be omitted, if only one modules exists within the command. | exactly once per command          |
+| main      | bool           | false   | Marks this module as the main module. All runtime arguments to a command are passed to its main module. The main module's usage information is also used as the command help text. | 0 or 1 times per command          |
 | args      | []string       | nil     | If a module is **not** an commands main module, it does not get any arguments passed at runtime, instead arguments can be passed here.                                                             | no, only applies if `main` is set |
 | options   | map[string]any |         | A module can be configured via key-value pairs. The type of the value is generic and depends on the implementation of the module.                                                                  | yes                               |
 


### PR DESCRIPTION
Main modules are now optional. Commands can have 0 or 1 main modules instead of requiring exactly 1. Arguments are only passed to commands that have a main module else they are ignored. This is not a breaking change as all old commands are still valid.

resolves #240 