### PR TITLE
feat: add flashprog support to flash module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Key features include:
 For detailed information on the system architecture, see the [Documentation](./docs/README.md).
 
 | Supported Client OS | Recommended DUT Agent Hardware |
-|---------------------|--------------------------------|
+| ------------------- | ------------------------------ |
 | Linux               | RaspberryPi 4                  |
 
 ## Getting Started
@@ -85,14 +85,13 @@ DUT agent on it. Below you can find the currently supported modules with example
 [here](./docs/dutagent-config.md), to learn how you can adapt the agent's configuration to your needs
 
 | Modules                                                            | Status                   |
-|--------------------------------------------------------------------|--------------------------|
+| ------------------------------------------------------------------ | ------------------------ |
 | [GPIO Button](./pkg/module/gpio/README.md)                         | :white_check_mark:       |
 | [GPIO Switch](./pkg/module/gpio/README.md)                         | :white_check_mark:       |
 | [IPMI Power Control](./pkg/module/gpio/README.md)                  | :white_check_mark:       |
 | [Power Distribution Unit (Intellinet)](./pkg/module/pdu/README.md) | :white_check_mark:       |
 | Power Distribution Unit (Delock)                                   | :hourglass_flowing_sand: |
-| [SPI Flasher (flashrom)](./pkg/module/flash/README.md)             | :white_check_mark:       |
-| SPI Flasher (flashprog)                                            | :hourglass_flowing_sand: |
+| [SPI Flasher](./pkg/module/flash/README.md)                        | :white_check_mark:       |
 | [Serial Console](./pkg/module/serial/README.md)                    | :white_check_mark:       |
 | [Shell Execution](./pkg/module/shell/README.md)                    | :white_check_mark:       |
 | [Secure Shell (SSH)](./pkg/module/ssh/README.md)                   | :white_check_mark:       |
@@ -118,6 +117,6 @@ Commons Fund. The NGI0 Commons Fund is made possible with financial support from
 [Next Generation Internet](https://ngi.eu/) program.
 
 |                              |                                    |                            |
-|------------------------------|------------------------------------|----------------------------|
+| ---------------------------- | ---------------------------------- | -------------------------- |
 | ![nlnet](./assets/nlnet.png) | ![European Union](./assets/EU.png) | ![NGI0](./assets/NGI0.png) |
 

--- a/pkg/module/flash/README.md
+++ b/pkg/module/flash/README.md
@@ -1,4 +1,4 @@
-The _shell_ package provides a single module:
+The _flash_ package provides a single module:
 
 # Flash
 
@@ -8,19 +8,20 @@ Read or write the SPI flash on the DUT.
 ARGUMENTS:
 	[read | write] <image>
 
-For read operation, <image> sets the filepath the read image is saved at the client. 
+For read operation, <image> sets the filepath the read image is saved at the client.
 For write operation, <image> is the local filepath to the image at the client.
 
 ```
 
-This module is a wrapper around flash-software on the _dutagent_. At the moment only _flashrom_ is supported.
-Other software will be configurable in this module later. The flasher software must be installed on the _dutagent_, and
- suitable flasher hardware must be hooked up to the DUT. Functionality is tested with DediProg programmers.
+This module is a wrapper around a flasher tool on the _dutagent_. Supported tools: _flashrom_, _flashprog_.
+The flasher tool must be installed on the _dutagent_, and suitable flasher hardware must be hooked up to the DUT.
+Functionality is tested with DediProg programmers.
 
-See [flash-example-cfg.yml](./flash-example-cfg.yml) for examples. 
+See [flash-example-cfg.yml](./flash-example-cfg.yml) for examples.
 
 ## Configuration Options
 
 | Option     | Value  | Description                                                                                       |
 |------------|--------|---------------------------------------------------------------------------------------------------|
 | programmer | string | Name of the flasher hardware, that is used by the _dutagent_ and attached to the DUT's SPI flash. |
+| tool       | string | Path to the flasher tool binary on the _dutagent_. Defaults to `/bin/flashrom` if not specified. Supported: flashrom, flashprog. |

--- a/pkg/module/flash/flash-example-cfg.yml
+++ b/pkg/module/flash/flash-example-cfg.yml
@@ -11,5 +11,5 @@ devices:
           - module: flash
             main: true
             options:
-              tool: "/usr/sbin/flashrom"
+              tool: "/usr/sbin/flashprog"
               programmer: "dediprog"

--- a/pkg/module/flash/flash.go
+++ b/pkg/module/flash/flash.go
@@ -27,7 +27,7 @@ func init() {
 		ID: "flash",
 		New: func() module.Module {
 			return &Flash{
-				supportedTools: []string{"flashrom"},
+				supportedTools: []string{"flashrom", "flashprog"},
 			}
 		},
 	})
@@ -52,8 +52,8 @@ const (
 type Flash struct {
 	// Programmer is the name of the flasher hardware.
 	Programmer string
-	// Tool is th path to the underlying flash-tool on the dutagent. If unset, [DefaultFlashTool] is used.
-	// Currently only fashrom is supported.
+	// Tool is the path to the underlying flash-tool on the dutagent. If unset, [DefaultFlashTool] is used.
+	// Supported tools: flashrom, flashprog.
 	Tool string
 
 	op              op       // op holds the current flash operation
@@ -78,8 +78,8 @@ const description = `
 For read operation, <image> sets the filepath the read image is saved at the client.
 For write operation, <image> is the local filepath to the image at the client.
 
-This module is a wrapper around a flash software on the dutagent. The flasher software 
-must be installed on the dutagent and a suitable flasher hardware must be hooked up to 
+This module is a wrapper around a flasher tool on the dutagent. The flasher tool
+must be installed on the dutagent and a suitable flasher hardware must be hooked up to
 the DUT.
 
 `


### PR DESCRIPTION
Extend flash module to support both flashrom and flashprog tools, allowing users to choose their preferred flash utility via configuration.