### PR TITLE
feat: add dpcmd support

### DIFF
--- a/pkg/module/flash/README.md
+++ b/pkg/module/flash/README.md
@@ -13,7 +13,7 @@ For write operation, <image> is the local filepath to the image at the client.
 
 ```
 
-This module is a wrapper around a flasher tool on the _dutagent_. Supported tools: _flashrom_, _flashprog_.
+This module is a wrapper around a flasher tool on the _dutagent_. Supported tools: _flashrom_, _flashprog_, _dpcmd_.
 The flasher tool must be installed on the _dutagent_, and suitable flasher hardware must be hooked up to the DUT.
 Functionality is tested with DediProg programmers.
 
@@ -23,5 +23,5 @@ See [flash-example-cfg.yml](./flash-example-cfg.yml) for examples.
 
 | Option     | Value  | Description                                                                                       |
 |------------|--------|---------------------------------------------------------------------------------------------------|
-| programmer | string | Name of the flasher hardware, that is used by the _dutagent_ and attached to the DUT's SPI flash. |
-| tool       | string | Path to the flasher tool binary on the _dutagent_. Defaults to `/bin/flashrom` if not specified. Supported: flashrom, flashprog. |
+| tool       | string | Path to the flasher tool binary on the _dutagent_. Supported: flashrom, flashprog, dpcmd. |
+| programmer | string | Specifics of the flasher hardware. For flashrom/flashprog: programmer name (e.g., "dediprog"). For dpcmd: (Optional) USB device number. Required for flashrom/flashprog, optional for dpcmd. See the respective flash-tool documentation for supported values. |


### PR DESCRIPTION
Add support for dpcmd (DediProg command-line tool) alongside flashrom and flashprog. Each tool now has tool-specific command-line generation to handle their different CLI syntax.

BREAKING CHANGE: Removed default tool. Users must now explicitly configure the tool option in their flash module configuration.