### PR TITLE
Rename dutagent config keys names

### DIFF
--- a/cmds/exp/contrib/config-1.yaml
+++ b/cmds/exp/contrib/config-1.yaml
@@ -6,6 +6,6 @@ devices:
     cmds:
       status:
         desc: "Report status"
-        modules:
+        uses:
           - module: dummy-status
             main: true

--- a/cmds/exp/contrib/config-2.yaml
+++ b/cmds/exp/contrib/config-2.yaml
@@ -6,11 +6,11 @@ devices:
     cmds:
       status:
         desc: "Report status"
-        modules:
+        uses:
           - module: dummy-status
             main: true
       repeat:
         desc: "Repeat input"
-        modules:
+        uses:
           - module: dummy-repeat
             main: true

--- a/contrib/dutagent-cfg-example.yaml
+++ b/contrib/dutagent-cfg-example.yaml
@@ -6,7 +6,7 @@ devices:
     cmds:
       status:
         desc: "Report status"
-        modules:
+        uses:
           - module: dummy-status
             main: true
   device2:
@@ -14,12 +14,12 @@ devices:
     cmds:
       status:
         desc: "Report status"
-        modules:
+        uses:
           - module: dummy-status
             main: true
       repeat:
         desc: "Repeat input"
-        modules:
+        uses:
           - module: dummy-repeat
             main: true
   device3:
@@ -27,14 +27,14 @@ devices:
     cmds:
       status:
         desc: "Report status"
-        modules:
+        uses:
           - module: dummy-status
             main: true
       file-transfer:
         desc: "Transfer a file"
-        modules:
+        uses:
           - module: dummy-status
-            args: 
+            args:
               - foo
               - bar
           - module: dummy-ft

--- a/docs/dutagent-config.md
+++ b/docs/dutagent-config.md
@@ -34,7 +34,7 @@ could look like.
 | Attribute   | Type                 | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                                                            | Mandatory |
 |-------------|----------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
 | description | string               |         | Command description                                                                                                                                                                                                                                                                                                                                                                                                                                    | no        |
-| Modules     | [] [Module](#Module) |         | A command may be composed of multiple steps to achieve its purpose. The list of modules represent these steps.The order of this list is important, though. Exactly one of the modules must be set as the main module. All arguments to a command are passed to its main module. The main modules usage information is also used as the command help text. If a Command is composed of only one module, this module becomes the main module implicitly. | yes       |
+| uses     | [] [Module](#Module) |         | A command may be composed of multiple steps to achieve its purpose. The list of modules represent these steps.The order of this list is important, though. Exactly one of the modules must be set as the main module. All arguments to a command are passed to its main module. The main modules usage information is also used as the command help text. If a Command is composed of only one module, this module becomes the main module implicitly. | yes       |
 
 ### Module
 
@@ -43,10 +43,10 @@ could look like.
 | module    | string         |         | The module's name also serves as its identifier and must be unique.                                                                                                                                | yes                               |
 | main      | bool           | false   | All arguments to a command are passed to its main module. The main modules usage information is also used as the command help text. Can be omitted, if only one modules exists within the command. | exactly once per command          |
 | args      | []string       | nil     | If a module is **not** an commands main module, it does not get any arguments passed at runtime, instead arguments can be passed here.                                                             | no, only applies if `main` is set |
-| options   | map[string]any |         | A module can be configured via key-value pairs. The type of the value is generic and depends on the implementation of the module.                                                                  | yes                               |
+| with   | map[string]any |         | A module can be configured via key-value pairs. The type of the value is generic and depends on the implementation of the module.                                                                  | yes                               |
 
 > [!IMPORTANT]  
-> Refer to option keys of a module in all-lowercase representation of the modules exported fields.
+> Refer to `with` keys of a module in all-lowercase representation of the module's exported fields.
 > See the respective module's documentation for details.
 
 ### Example config file

--- a/docs/module_guide.md
+++ b/docs/module_guide.md
@@ -57,9 +57,8 @@ _ "github.com/BlindspotSoftware/dutctl/pkg/module/dummy"
 ```
 
 ## Configuration
-
-A module can be dynamically configured when starting a _dutagent_ using the option map in the
-[_dutagent_ configuration](./dutagent-config.md#module). A module must be of type `struct` and have the options as
+A module can be dynamically configured when starting a _dutagent_ using the `with` map in the
+[_dutagent_ configuration](./dutagent-config.md#module). A module must be of type `struct` and have the configuration as
 fields. The parser will set the struct fields to match the map keys.
 
 For example, a module like the one below, registered with `ID` = `"my-module"`.
@@ -81,15 +80,15 @@ devices:
     cmds:
       some-cmd:
         desc: My cool module
-        modules:
+        uses:
           - module: my-module
-            options:
+            with:
               foo: 42
 ```
 
 > [!IMPORTANT]  
-> It is imperative that the module's documentation and Help() function provide a good explanation of its options.
-> The option map in the configuration file is generic (string → any type), so it is important that the user knows what
+> It is imperative that the module's documentation and Help() function provide a good explanation of its configuration.
+> The `with` map in the configuration file is generic (string → any type), so it is important that the user knows what
 > values are expected.
 
 The [project's dummy modules](../pkg/module/dummy/dummy_status.go) show all the details of a complete implementation.

--- a/pkg/dut/dut.go
+++ b/pkg/dut/dut.go
@@ -90,7 +90,7 @@ type Device struct {
 // modules and are executed in the order they are defined.
 type Command struct {
 	Desc    string
-	Modules []Module
+	Modules []Module `yaml:"uses"`
 }
 
 // commandAlias is used when parsing YAML to avoid recursion.
@@ -153,7 +153,7 @@ type ModuleConfig struct {
 	Name    string `yaml:"module"`
 	Main    bool
 	Args    []string
-	Options map[string]any
+	Options map[string]any `yaml:"with"`
 }
 
 // UnmarshalYAML unmarshals a Module from a YAML node and adds custom validation.
@@ -178,7 +178,7 @@ func (m *Module) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 
-	// validate Module options
+	// validate Module configuration
 	validate := validator.New()
 
 	err = validate.Struct(m.Module)

--- a/pkg/module/agent/README.md
+++ b/pkg/module/agent/README.md
@@ -18,7 +18,7 @@ The agent-status module can be used in a command like so.
 cmds:
       system-info:
         desc: "This simple command reports information about the dutagent system via the agent-status module."
-        modules:
+        uses:
           - module: agent-status
             main: true
 ```

--- a/pkg/module/file/file-example-cfg.yml
+++ b/pkg/module/file/file-example-cfg.yml
@@ -8,10 +8,10 @@ devices:
       # Upload any file - preserves directory structure
       upload:
         desc: "Upload file to device"
-        modules:
+        uses:
           - module: file
             main: true
-            options:
+            with:
               operation: "upload"
         # Usage:
         #   dutctl example-device upload ./build/firmware.bin
@@ -23,10 +23,10 @@ devices:
       # Upload with destination configured - arg becomes source
       upload-script:
         desc: "Upload and install a script"
-        modules:
+        uses:
           - module: file
             main: true
-            options:
+            with:
               operation: "upload"
               destination: "/opt/scripts/install.sh"
               permission: "0755" # Make it executable
@@ -37,10 +37,10 @@ devices:
       # Download with source configured - arg becomes destination
       fetch-logs:
         desc: "Download logs from device"
-        modules:
+        uses:
           - module: file
             main: true
-            options:
+            with:
               operation: "download"
               source: "/var/log.txt"
         # Usage:
@@ -50,10 +50,10 @@ devices:
       # Upload with both paths configured - no arg allowed
       upload-config:
         desc: "Upload configuration file with fixed paths"
-        modules:
+        uses:
           - module: file
             main: true
-            options:
+            with:
               operation: "upload"
               source: "./configs/device.conf"
               destination: "/etc/device/device.conf"

--- a/pkg/module/flash/flash-example-cfg.yml
+++ b/pkg/module/flash/flash-example-cfg.yml
@@ -7,9 +7,9 @@ devices:
       flash:
         desc: |
           Basic demo of the Flash module.
-        modules:
+        uses:
           - module: flash
             main: true
-            options:
+            with:
               tool: "/usr/sbin/flashprog"
               programmer: "dediprog"

--- a/pkg/module/gpio/gpio-example-cfg.yml
+++ b/pkg/module/gpio/gpio-example-cfg.yml
@@ -6,24 +6,24 @@ devices:
     cmds:
       fire:
         desc: "Push the big red button"
-        modules:
+        uses:
           - module: gpio-button
             main: true
-            options:
+            with:
               pin: 9
       reset:
         desc: "Reset the rocket"
-        modules:
+        uses:
           - module: gpio-button
             main: true
-            options:
+            with:
               pin: 10
               activelow: true
       light:
         desc: "Turn on the light"
-        modules:
+        uses:
           - module: gpio-switch
             main: true
-            options:
+            with:
               pin: 11
               initial: on

--- a/pkg/module/ipmi/ipmi-example-cfg.yml
+++ b/pkg/module/ipmi/ipmi-example-cfg.yml
@@ -5,9 +5,9 @@ devices:
     cmds:
       power:
         desc: "Power on the server using IPMI"
-        modules:
+        uses:
           - module: ipmi-power
-            options:
+            with:
               host: 192.168.1.100
               port: 623
               user: user

--- a/pkg/module/pdu/pdu-example-cfg.yml
+++ b/pkg/module/pdu/pdu-example-cfg.yml
@@ -5,10 +5,10 @@ devices:
     cmds:
       power-on:
         desc: "Turn the power ON via PDU"
-        modules:
+        uses:
           - module: pdu
             main: true
-            options:
+            with:
               host: http://192.168.1.100
               user: admin
               password: admin

--- a/pkg/module/serial/serial-example-cfg.yml
+++ b/pkg/module/serial/serial-example-cfg.yml
@@ -7,9 +7,9 @@ devices:
         desc: |
           Basic demo of the Serial module: After the DUT is powered on, use Serial
           as the main module to wait for magic strings in the DUT's boot log.
-        modules:
+        uses:
           - module: serial
             main: true
-            options:
+            with:
               port: /tmp/ttyS0
               baudrate: 115200

--- a/pkg/module/shell/shell-example-cfg.yml
+++ b/pkg/module/shell/shell-example-cfg.yml
@@ -10,9 +10,9 @@ devices:
         desc: |
           Demonstrates the shell module by writing a greeting to a file, giving the user the chance to edit, 
           then reading it back and deleting the file. E.g try: dutctl self greet "echo 'Hello World' >> /tmp/shell-test.txt"
-        modules:
+        uses:
           - module: shell
-            options:
+            with:
               path: bash
               quiet: true
             args:
@@ -20,13 +20,13 @@ devices:
           - module: shell
             main: true
           - module: shell
-            options:
+            with:
               path: sh
               quiet: true
             args:
               - "ls /tmp/shell-test.txt"
           - module: shell
-            options:
+            with:
               path: /bin/bash
             args:
               - "cat /tmp/shell-test.txt && rm -f /tmp/shell-test.txt"

--- a/pkg/module/ssh/ssh-example-cfg.yml
+++ b/pkg/module/ssh/ssh-example-cfg.yml
@@ -9,10 +9,10 @@ devices:
           "Basic demo of the SSH module: Use SSH as the main module to connect
           to the DUT. The SSH module is used to connect from the dutagent to the DUT
           and execute commands that are passed to the module from the dutctl client.
-        modules:
+        uses:
           - module: ssh
             main: true
-            options:
+            with:
               host: enigma
               user: oscar
               privatekey: ./keys/id_ed25519

--- a/pkg/module/time/time-example-cfg.yml
+++ b/pkg/module/time/time-example-cfg.yml
@@ -6,16 +6,15 @@ devices:
     cmds:
       system-double-check:
         desc: "Report status twice"
-        modules:
+        uses:
           - module: agent-status
             main: true
           - module: time-wait
-            options:
+            with:
               duration: 2s
           - module: agent-status
       just-wait:
         desc: "Do nothing and finish after the provided amount of time"
-        modules:
+        uses:
           - module: time-wait
             main: true
-  

--- a/pkg/module/wifisocket/wifisocket-example-cfg.yml
+++ b/pkg/module/wifisocket/wifisocket-example-cfg.yml
@@ -5,10 +5,10 @@ devices:
     cmds:
       power:
         desc: "Control the power via WiFi socket"
-        modules:
+        uses:
           - module: wifisocket
             main: true
-            options:
+            with:
               host: http://192.168.1.60
               user: "user"
               password: "password"


### PR DESCRIPTION
resolves #238 

I've opted to not rename the struct fields but add yaml tags for better clarity. So the `uses` yaml field will still map to `Modules`, which is used all over the codebase.