### PR TITLE
fix(module/serial): defer port opening to runtime

### DIFF
--- a/pkg/module/serial/serial.go
+++ b/pkg/module/serial/serial.go
@@ -86,11 +86,9 @@ func (s *Serial) Init() error {
 		s.Baud = DefaultBaudRate
 	}
 
-	port, err := s.openPort()
-	if err != nil {
-		return err
-	}
-	defer port.Close()
+	// Note: We don't open the port here to allow dutagent to start
+	// even if the serial device is not yet available (e.g., powered off).
+	// The port will be opened when Run() is called.
 
 	return nil
 }


### PR DESCRIPTION
This allows dutagent to start even when serial devices don't exist yet (e.g., target powered off).