### PR TITLE
feat: add emulate module for em100 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ DUT agent on it. Below you can find the currently supported modules with example
 | [IPMI Power Control](./pkg/module/ipmi/README.md)                  | :white_check_mark:       |
 | [Power Distribution Unit (Intellinet)](./pkg/module/pdu/README.md) | :white_check_mark:       |
 | Power Distribution Unit (Delock)                                   | :hourglass_flowing_sand: |
+| [SPI Flash Emulator](./pkg/module/flash-emulate/README.md)         | :white_check_mark:       |
 | [SPI Flasher](./pkg/module/flash/README.md)                        | :white_check_mark:       |
 | [Serial Console](./pkg/module/serial/README.md)                    | :white_check_mark:       |
 | [Shell Execution](./pkg/module/shell/README.md)                    | :white_check_mark:       |

--- a/cmds/dutagent/modules.go
+++ b/cmds/dutagent/modules.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/dummy"
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/file"
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/flash"
+	_ "github.com/BlindspotSoftware/dutctl/pkg/module/flash-emulate"
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/gpio"
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/ipmi"
 	_ "github.com/BlindspotSoftware/dutctl/pkg/module/pdu"

--- a/internal/test/mock/session.go
+++ b/internal/test/mock/session.go
@@ -23,6 +23,7 @@ type Session struct {
 	RequestFileCalled     bool
 	RequestedFileName     string
 	RequestedFileResponse io.Reader
+	RequestFileErr        error
 	SendFileCalled        bool
 	SentFileName          string
 	SentFileContent       []byte
@@ -67,6 +68,10 @@ func (m *Session) Console() (stdin io.Reader, stdout, stderr io.Writer) {
 func (m *Session) RequestFile(name string) (io.Reader, error) {
 	m.RequestFileCalled = true
 	m.RequestedFileName = name
+
+	if m.RequestFileErr != nil {
+		return nil, m.RequestFileErr
+	}
 
 	if m.RequestedFileResponse == nil {
 		panic("mock.Session: RequestedFileResponse not set")

--- a/pkg/module/flash-emulate/README.md
+++ b/pkg/module/flash-emulate/README.md
@@ -1,0 +1,29 @@
+The _flash-emulate_ package provides a single module:
+
+# FlashEmulate
+
+Load a firmware image into an SPI flash emulator on the DUT.
+
+```
+ARGUMENTS:
+	<image>
+
+<image> is the local filepath to the firmware image at the client.
+
+```
+
+The image is transferred to the _dutagent_ and loaded into the SPI flash emulator.
+Any running emulation session is stopped first, then the new image is loaded and emulation is started.
+
+This module wraps an emulation tool on the _dutagent_ (default: `em100`). The tool must be installed on the _dutagent_,
+and a compatible emulator (e.g. EM100Pro-G2 from Dediprog) must be connected to the DUT's SPI flash bus.
+
+See [flash-emulate-example-cfg.yml](./flash-emulate-example-cfg.yml) for examples.
+
+## Configuration Options
+
+| Option | Value  | Required | Description                                                                                                         |
+|--------|--------|----------|---------------------------------------------------------------------------------------------------------------------|
+| chip   | string | yes      | SPI flash chip type identifier (e.g. `N25Q256A13`). See the `em100` documentation for the list of supported chips. |
+| tool   | string | no       | Path to the emulation tool binary on the _dutagent_. Defaults to `em100`.                                          |
+| device | string | no       | USB device number to select a specific emulator when multiple are connected.                                        |

--- a/pkg/module/flash-emulate/flash-emulate-example-cfg.yml
+++ b/pkg/module/flash-emulate/flash-emulate-example-cfg.yml
@@ -1,0 +1,16 @@
+---
+version: 0
+devices:
+  xyz:
+    desc: "A mainboard that uses a Dediprog EM100Pro-G2 flash emulator during firmware development"
+    cmds:
+      flash-emulate:
+        desc: |
+          Basic demo of the FlashEmulate module.
+        uses:
+          - module: flash-emulate
+            main: true
+            with:
+              chip: "N25Q256A13"
+              # tool: "/usr/local/bin/em100"  # optional, defaults to em100
+              # device: "0"                    # optional, for multiple emulators

--- a/pkg/module/flash-emulate/flash-emulate.go
+++ b/pkg/module/flash-emulate/flash-emulate.go
@@ -1,0 +1,239 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package flashemulate provides a dutagent module that loads a firmware image into an SPI flash emulator.
+// This module is a wrapper around an emulation tool (default: em100) that is executed on a dutagent.
+package flashemulate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/BlindspotSoftware/dutctl/pkg/module"
+)
+
+func init() {
+	module.Register(module.Record{
+		ID: "flash-emulate",
+		New: func() module.Module {
+			return &FlashEmulate{
+				Tool: defaultTool,
+			}
+		},
+	})
+}
+
+const defaultTool = "em100"
+
+// tmpDirPerm is the permission bits used when creating the temporary image directory.
+const tmpDirPerm = 0o700
+
+// FlashEmulate is a module that loads a firmware image into an SPI flash emulator connected to the DUT.
+type FlashEmulate struct {
+	// Tool is the path to the emulation tool on the dutagent. Defaults to "em100".
+	Tool string `yaml:"tool"`
+	// Chip is the SPI flash chip type identifier to emulate (e.g. "N25Q256A13"). Required.
+	Chip string `yaml:"chip"`
+	// Device is the USB device number used when multiple emulators are connected. Optional.
+	Device string `yaml:"device"`
+
+	localImagePath  string // localImagePath is the path to the firmware image on the dutagent
+	clientImagePath string // clientImagePath is the image path as named by the client
+}
+
+// Ensure implementing the Module interface.
+var _ module.Module = &FlashEmulate{}
+
+const abstract = `Load a firmware image into an SPI flash emulator on the DUT.
+`
+
+const usage = `
+ARGUMENTS:
+	<image>
+
+`
+
+const description = `
+<image> is the local filepath to the firmware image at the client.
+
+The image is transferred to the dutagent and loaded into the SPI flash emulator.
+Any running emulation session is stopped first, then the new image is loaded and
+emulation is started.
+
+This module wraps an emulation tool on the dutagent (default: em100). The tool
+must be installed on the dutagent and a compatible emulator (e.g. EM100Pro-G2
+from Dediprog) must be connected to the DUT's SPI flash bus.
+
+`
+
+func (e *FlashEmulate) Help() string {
+	log.Println("flash-emulate module: Help called")
+
+	help := strings.Builder{}
+	help.WriteString(abstract)
+	help.WriteString(usage)
+	help.WriteString(description)
+	help.WriteString(fmt.Sprintf("Using %q as emulation tool with chip %q.\n", e.Tool, e.Chip))
+
+	if e.Device != "" {
+		help.WriteString(fmt.Sprintf("Using USB device %q.\n", e.Device))
+	}
+
+	return help.String()
+}
+
+func (e *FlashEmulate) Init() error {
+	log.Println("flash-emulate module: Init called")
+
+	if e.Tool == "" {
+		e.Tool = defaultTool
+	}
+
+	_, err := exec.LookPath(e.Tool)
+	if err != nil {
+		return fmt.Errorf("emulation tool %q: %w", e.Tool, err)
+	}
+
+	if e.Chip == "" {
+		return errors.New("chip must be configured (e.g. \"N25Q256A13\")")
+	}
+
+	return nil
+}
+
+func (e *FlashEmulate) Deinit() error {
+	log.Println("flash-emulate module: Deinit called")
+
+	return os.RemoveAll(e.localImagePath)
+}
+
+func (e *FlashEmulate) Run(_ context.Context, sesh module.Session, args ...string) error {
+	log.Println("flash-emulate module: Run called")
+
+	if len(args) < 1 {
+		return errors.New("missing argument: image file path")
+	}
+
+	e.clientImagePath = args[0]
+
+	// Clean up any image file left over from a previous Run call on this instance.
+	if e.localImagePath != "" {
+		_ = os.RemoveAll(e.localImagePath)
+		e.localImagePath = ""
+	}
+
+	tmpDir := os.TempDir()
+
+	err := os.MkdirAll(tmpDir, tmpDirPerm)
+	if err != nil {
+		return fmt.Errorf("create temp dir for image: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp(tmpDir, "flash-emulate-image-*")
+	if err != nil {
+		return fmt.Errorf("create temp image file: %w", err)
+	}
+
+	tmpFile.Close()
+
+	e.localImagePath = tmpFile.Name()
+
+	err = uploadImage(sesh, e.clientImagePath, e.localImagePath)
+	if err != nil {
+		_ = os.RemoveAll(e.localImagePath)
+		e.localImagePath = ""
+
+		return err
+	}
+
+	cmdArgs := e.cmdline()
+
+	log.Printf("flash-emulate module: Executing command: %s %s", e.Tool, strings.Join(cmdArgs, " "))
+	sesh.Print(fmt.Sprintf("Executing: %s %s", e.Tool, strings.Join(cmdArgs, " ")))
+
+	err = execute(sesh, e.Tool, cmdArgs...)
+	if err != nil {
+		_ = os.RemoveAll(e.localImagePath)
+		e.localImagePath = ""
+
+		return fmt.Errorf("emulation failed: %w", err)
+	}
+
+	sesh.Print("Emulation started successfully")
+
+	return nil
+}
+
+// cmdline returns the argument list for the emulation tool:
+// [--device <n>] --stop --set <chip> -d <image> -v --start.
+func (e *FlashEmulate) cmdline() []string {
+	var args []string
+
+	if e.Device != "" {
+		args = append(args, "--device", e.Device)
+	}
+
+	args = append(args, "--stop", "--set", e.Chip, "-d", e.localImagePath, "-v", "--start")
+
+	return args
+}
+
+// uploadImage receives the firmware image file from sesh and saves it locally.
+func uploadImage(sesh module.Session, remote, local string) error {
+	img, err := sesh.RequestFile(remote)
+	if err != nil {
+		return fmt.Errorf("request image from client: %w", err)
+	}
+
+	imgFile, err := os.Create(local)
+	if err != nil {
+		return fmt.Errorf("save image on dutagent: %w", err)
+	}
+
+	_, err = io.Copy(imgFile, img)
+	if err != nil {
+		_ = imgFile.Close()
+		_ = os.Remove(local)
+
+		return fmt.Errorf("save image on dutagent: %w", err)
+	}
+
+	err = imgFile.Close()
+	if err != nil {
+		_ = os.Remove(local)
+
+		return fmt.Errorf("save image on dutagent: %w", err)
+	}
+
+	return nil
+}
+
+func execute(sesh module.Session, tool string, args ...string) error {
+	//nolint:noctx
+	cmd := exec.Command(tool, args...)
+
+	output, err := cmd.CombinedOutput()
+
+	if len(output) > 0 {
+		log.Printf("flash-emulate module: tool output:\n%s", output)
+		sesh.Print(string(output))
+	}
+
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return fmt.Errorf("emulation tool exited with code %d", exitErr.ExitCode())
+		}
+
+		return fmt.Errorf("failed to execute %s: %w", tool, err)
+	}
+
+	return nil
+}

--- a/pkg/module/flash-emulate/flash-emulate_test.go
+++ b/pkg/module/flash-emulate/flash-emulate_test.go
@@ -1,0 +1,315 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package flashemulate
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BlindspotSoftware/dutctl/internal/test/mock"
+)
+
+func TestInit(t *testing.T) {
+	tests := []struct {
+		name        string
+		flashEmulate FlashEmulate
+		expectErr   bool
+	}{
+		{
+			name:        "valid config",
+			flashEmulate: FlashEmulate{Tool: "/bin/sh", Chip: "N25Q256A13"},
+			expectErr:   false,
+		},
+		{
+			name:        "missing chip",
+			flashEmulate: FlashEmulate{Tool: "/bin/sh"},
+			expectErr:   true,
+		},
+		{
+			name:        "tool not found",
+			flashEmulate: FlashEmulate{Tool: "this-tool-does-not-exist-xyzabc123", Chip: "N25Q256A13"},
+			expectErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.flashEmulate.Init()
+			if (err != nil) != tt.expectErr {
+				t.Errorf("unexpected error state (wantErr=%v): %v", tt.expectErr, err)
+			}
+		})
+	}
+}
+
+func TestInitDefaultTool(t *testing.T) {
+	// Create a fake em100 binary in a temp dir so the test is hermetic.
+	dir := t.TempDir()
+	fakeTool := filepath.Join(dir, defaultTool)
+
+	if err := os.WriteFile(fakeTool, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	e := FlashEmulate{Chip: "N25Q256A13"}
+
+	if err := e.Init(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if e.Tool != defaultTool {
+		t.Errorf("expected Tool to be defaulted to %q, got %q", defaultTool, e.Tool)
+	}
+}
+
+func TestDeinit(t *testing.T) {
+	t.Run("no image to clean up", func(t *testing.T) {
+		e := FlashEmulate{}
+		if err := e.Deinit(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("removes image file on cleanup", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "flash-emulate-test-*")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		f.Close()
+
+		e := FlashEmulate{localImagePath: f.Name()}
+		if err := e.Deinit(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if _, statErr := os.Stat(f.Name()); !os.IsNotExist(statErr) {
+			t.Errorf("expected file %q to be removed after Deinit", f.Name())
+		}
+	})
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name        string
+		flashEmulate FlashEmulate
+		args        []string
+		expectErr   bool
+	}{
+		{
+			name:        "missing image argument",
+			flashEmulate: FlashEmulate{Tool: "/bin/sh", Chip: "N25Q256A13"},
+			args:        []string{},
+			expectErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sesh := &mock.Session{}
+			ctx := context.Background()
+
+			err := tt.flashEmulate.Run(ctx, sesh, tt.args...)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("unexpected error state (wantErr=%v): %v", tt.expectErr, err)
+			}
+		})
+	}
+
+	t.Run("successful run uploads image and invokes tool", func(t *testing.T) {
+		dir := t.TempDir()
+		fakeTool := filepath.Join(dir, "em100")
+
+		if err := os.WriteFile(fakeTool, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		sesh := &mock.Session{
+			RequestedFileResponse: strings.NewReader("fake firmware content"),
+		}
+
+		e := FlashEmulate{Tool: fakeTool, Chip: "N25Q256A13"}
+
+		if err := e.Run(context.Background(), sesh, "firmware.rom"); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if !sesh.RequestFileCalled {
+			t.Error("expected RequestFile to be called")
+		}
+
+		if sesh.RequestedFileName != "firmware.rom" {
+			t.Errorf("expected requested file name %q, got %q", "firmware.rom", sesh.RequestedFileName)
+		}
+
+		if err := e.Deinit(); err != nil {
+			t.Errorf("unexpected Deinit error: %v", err)
+		}
+	})
+
+	t.Run("uploadImage failure cleans up temp file", func(t *testing.T) {
+		sesh := &mock.Session{
+			RequestFileErr: errors.New("fake transfer error"),
+		}
+
+		e := FlashEmulate{Tool: "/bin/sh", Chip: "N25Q256A13"}
+
+		if err := e.Run(context.Background(), sesh, "firmware.rom"); err == nil {
+			t.Error("expected error but got nil")
+		}
+
+		if e.localImagePath != "" {
+			t.Errorf("expected localImagePath to be empty after failure, got %q", e.localImagePath)
+		}
+	})
+
+	t.Run("execute failure cleans up temp file", func(t *testing.T) {
+		dir := t.TempDir()
+		fakeTool := filepath.Join(dir, "em100")
+
+		if err := os.WriteFile(fakeTool, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		sesh := &mock.Session{
+			RequestedFileResponse: strings.NewReader("fake firmware"),
+		}
+
+		e := FlashEmulate{Tool: fakeTool, Chip: "N25Q256A13"}
+
+		if err := e.Run(context.Background(), sesh, "firmware.rom"); err == nil {
+			t.Error("expected error but got nil")
+		}
+
+		if e.localImagePath != "" {
+			t.Errorf("expected localImagePath to be empty after failure, got %q", e.localImagePath)
+		}
+	})
+
+	t.Run("second run cleans up temp file from first run", func(t *testing.T) {
+		dir := t.TempDir()
+		fakeTool := filepath.Join(dir, "em100")
+
+		if err := os.WriteFile(fakeTool, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		e := FlashEmulate{Tool: fakeTool, Chip: "N25Q256A13"}
+		ctx := context.Background()
+
+		sesh1 := &mock.Session{RequestedFileResponse: strings.NewReader("firmware v1")}
+		if err := e.Run(ctx, sesh1, "fw1.rom"); err != nil {
+			t.Fatalf("first Run failed: %v", err)
+		}
+
+		firstPath := e.localImagePath
+
+		sesh2 := &mock.Session{RequestedFileResponse: strings.NewReader("firmware v2")}
+		if err := e.Run(ctx, sesh2, "fw2.rom"); err != nil {
+			t.Fatalf("second Run failed: %v", err)
+		}
+
+		if _, statErr := os.Stat(firstPath); !os.IsNotExist(statErr) {
+			t.Errorf("expected first temp file %q to be cleaned up before second run", firstPath)
+		}
+
+		if err := e.Deinit(); err != nil {
+			t.Errorf("unexpected Deinit error: %v", err)
+		}
+	})
+}
+
+func TestHelp(t *testing.T) {
+	tests := []struct {
+		name          string
+		flashEmulate  FlashEmulate
+		expectStrings []string
+	}{
+		{
+			name:         "contains chip and tool",
+			flashEmulate: FlashEmulate{Tool: "em100", Chip: "N25Q256A13"},
+			expectStrings: []string{
+				"em100",
+				"N25Q256A13",
+				"image",
+			},
+		},
+		{
+			name:         "contains device number when set",
+			flashEmulate: FlashEmulate{Tool: "em100", Chip: "N25Q256A13", Device: "2"},
+			expectStrings: []string{
+				"em100",
+				"N25Q256A13",
+				"2",
+			},
+		},
+		{
+			name:         "reflects custom chip name",
+			flashEmulate: FlashEmulate{Tool: "em100", Chip: "W25Q128JV"},
+			expectStrings: []string{
+				"W25Q128JV",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helpStr := tt.flashEmulate.Help()
+			for _, s := range tt.expectStrings {
+				if !strings.Contains(helpStr, s) {
+					t.Errorf("expected %q to appear in Help output:\n%s", s, helpStr)
+				}
+			}
+		})
+	}
+}
+
+func TestCmdline(t *testing.T) {
+	tests := []struct {
+		name        string
+		flashEmulate FlashEmulate
+		expected    []string
+	}{
+		{
+			name: "basic cmdline without device",
+			flashEmulate: FlashEmulate{
+				Chip:           "N25Q256A13",
+				localImagePath: "./flash-emulate-image",
+			},
+			expected: []string{"--stop", "--set", "N25Q256A13", "-d", "./flash-emulate-image", "-v", "--start"},
+		},
+		{
+			name: "cmdline with device selector",
+			flashEmulate: FlashEmulate{
+				Chip:           "N25Q256A13",
+				Device:         "1",
+				localImagePath: "./flash-emulate-image",
+			},
+			expected: []string{"--device", "1", "--stop", "--set", "N25Q256A13", "-d", "./flash-emulate-image", "-v", "--start"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.flashEmulate.cmdline()
+
+			if len(got) != len(tt.expected) {
+				t.Fatalf("cmdline length: expected %d args %v, got %d args %v", len(tt.expected), tt.expected, len(got), got)
+			}
+
+			for i := range tt.expected {
+				if got[i] != tt.expected[i] {
+					t.Errorf("arg[%d]: expected %q, got %q", i, tt.expected[i], got[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a new dutagent module that loads a firmware image into a SPI flash emulator connected to the DUT. The module wraps the em100 tool, stops any running emulation, loads the transferred image, and starts a new emulation session.

Configuration requires the flash chip identifier (e.g. N25Q256A13) and optionally a USB device number for setups with multiple emulators. The tool path defaults to em100.