### PR TITLE
Don't cancel run context on stdin EOF in dutctl client

### DIFF
--- a/cmds/dutctl/rpc.go
+++ b/cmds/dutctl/rpc.go
@@ -226,10 +226,17 @@ func (app *application) runRPC(device, command string, cmdArgs []string) error {
 		}
 	}()
 
-	// Send routine
+	// Send routine — reads lines from stdin and forwards them to the server.
+	//
+	// Unlike the receive routine this goroutine intentionally does NOT defer
+	// cancel(). When stdin reaches EOF (e.g. /dev/null in non-interactive
+	// runs) this goroutine returns immediately. If it cancelled the context
+	// on exit, the receive routine would be torn down before it could read
+	// and print the server's response.
+	//
+	// Only the receive routine drives context cancellation so that all
+	// server output is processed before the RPC terminates.
 	go func() {
-		defer cancel()
-
 		reader := bufio.NewReader(app.stdin)
 
 		for {


### PR DESCRIPTION
The send goroutine's defer cancel() caused the receive goroutine to be torn down immediately when stdin was /dev/null (e.g. non-interactive runs), resulting in no output being printed. Only the receive goroutine should drive context cancellation so that all server responses are processed before the RPC terminates.

Closes #306 