### PR TITLE
Embed release version

### DIFF
--- a/cmds/dutagent/dutagent.go
+++ b/cmds/dutagent/dutagent.go
@@ -81,7 +81,7 @@ type agent struct {
 
 // config holds the dutagent configuration that is parsed from YAML data.
 type config struct {
-	Version int
+	Version string
 	Devices dut.Devlist
 }
 

--- a/cmds/dutagent/testdata/invalid_config_empty_devices.yaml
+++ b/cmds/dutagent/testdata/invalid_config_empty_devices.yaml
@@ -1,3 +1,3 @@
 ---
-version: 0
+version: 1.0.0-alpha.1
 devices: {}

--- a/cmds/dutagent/testdata/valid_config.yaml
+++ b/cmds/dutagent/testdata/valid_config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0
+version: 1.0.0-alpha.1
 devices:
   device1:
     desc: "Device 1"

--- a/cmds/exp/contrib/config-1.yaml
+++ b/cmds/exp/contrib/config-1.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   device1:
     desc: "Device 1"

--- a/cmds/exp/contrib/config-2.yaml
+++ b/cmds/exp/contrib/config-2.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   device2:
     desc: "Device 2"

--- a/contrib/dutagent-cfg-example.yaml
+++ b/contrib/dutagent-cfg-example.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   device1:
     desc: "Device 1"

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -51,13 +51,13 @@ func (i *info) String() string {
 func (i *info) read() {
 	const unknown = "unknown"
 
+	i.semver = Version
+
 	if bi, ok := debug.ReadBuildInfo(); ok {
-		i.semver = bi.Main.Version
 		i.revision = cvsShortHash(findSetting("vcs.revision", bi.Settings))
 		i.time = parseTime(findSetting("vcs.time", bi.Settings))
 		i.compiler = bi.GoVersion
 	} else {
-		i.semver = unknown
 		i.revision = unknown
 		i.time = time.Time{}
 		i.compiler = unknown

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -1,0 +1,9 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package buildinfo
+
+// Version is the released semantic version of the application.
+// It is bumped automatically by release-please on every release.
+const Version = "1.0.0-alpha.1" // x-release-please-version

--- a/pkg/module/dummy/dummy-example-cfg.yml
+++ b/pkg/module/dummy/dummy-example-cfg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   self:
     desc: |

--- a/pkg/module/file/file-example-cfg.yml
+++ b/pkg/module/file/file-example-cfg.yml
@@ -2,6 +2,7 @@
 # This file demonstrates various use cases for file transfers between client and dutagent
 # $WD is a placeholder of the working directory on both the client and dutagent
 
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   example-device:
     cmds:

--- a/pkg/module/flash-emulate/flash-emulate-example-cfg.yml
+++ b/pkg/module/flash-emulate/flash-emulate-example-cfg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   xyz:
     desc: "A mainboard that uses a Dediprog EM100Pro-G2 flash emulator during firmware development"

--- a/pkg/module/flash/flash-example-cfg.yml
+++ b/pkg/module/flash/flash-example-cfg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   xyz:
     desc: "A mainboard that needs to be flashed during firmware development"

--- a/pkg/module/gpio/gpio-example-cfg.yml
+++ b/pkg/module/gpio/gpio-example-cfg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   rocket:
     desc: "A rocket that can be fired"

--- a/pkg/module/ipmi/ipmi-example-cfg.yml
+++ b/pkg/module/ipmi/ipmi-example-cfg.yml
@@ -1,4 +1,4 @@
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   fancy-server:
     desc: "A server with IPMI-managed power control"

--- a/pkg/module/pdu/pdu-example-cfg.yml
+++ b/pkg/module/pdu/pdu-example-cfg.yml
@@ -1,4 +1,4 @@
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   fancy-server:
     desc: "A server with power control via PDU"

--- a/pkg/module/serial/serial-example-cfg.yml
+++ b/pkg/module/serial/serial-example-cfg.yml
@@ -1,4 +1,4 @@
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   server:
     desc: "A server that needs to be observed during boot"

--- a/pkg/module/shell/shell-example-cfg.yml
+++ b/pkg/module/shell/shell-example-cfg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   self:
     desc: |

--- a/pkg/module/ssh/ssh-example-cfg.yml
+++ b/pkg/module/ssh/ssh-example-cfg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   laptop:
     desc: "A laptop computer"

--- a/pkg/module/time/time-example-cfg.yml
+++ b/pkg/module/time/time-example-cfg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   self:
     desc: "This device represents no DUT but the dutagent itself"

--- a/pkg/module/wifisocket/wifisocket-example-cfg.yml
+++ b/pkg/module/wifisocket/wifisocket-example-cfg.yml
@@ -1,4 +1,4 @@
-version: 0
+version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   nous-a1t:
     desc: "Device powered via Tasmota NOUS A1T WiFi socket"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -46,6 +46,11 @@
         }
     ],
     "packages": {
-        ".": {}
+        ".": {
+            "extra-files": [
+                "internal/buildinfo/version.go",
+                "contrib/dutagent-cfg-example.yaml"
+            ]
+        }
     }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -49,7 +49,24 @@
         ".": {
             "extra-files": [
                 "internal/buildinfo/version.go",
-                "contrib/dutagent-cfg-example.yaml"
+                {
+                    "type": "yaml",
+                    "path": "contrib/*.yaml",
+                    "glob": true,
+                    "jsonpath": "$.version"
+                },
+                {
+                    "type": "yaml",
+                    "path": "cmds/exp/contrib/*.yaml",
+                    "glob": true,
+                    "jsonpath": "$.version"
+                },
+                {
+                    "type": "yaml",
+                    "path": "pkg/module/*/*-example-cfg.yml",
+                    "glob": true,
+                    "jsonpath": "$.version"
+                }
             ]
         }
     }


### PR DESCRIPTION
## Summary
Bind dutagent/dutctl binaries to the release version managed by release-please. 

feat - `const Version` in `internal/buildinfo/version.go`, annotated for release-please. Replaces `debug.ReadBuildInfo().Main.Version` (always (`devel`) for go build). VCS revision, build time, Go version still come from runtime build info.
refactor - `config.Version int` → string so it can hold semver. Parsed but unused.
ci - ` extra-files` wired so releases bump `version.go `and `contrib/dutagent-cfg-example.yaml`.
## Not part of this PR
Config compatibility validation is deferred. Policy still TBD (exact match? major-only? schema version decoupled?). config.Version is read but never compared to buildinfo.Version.
 
It partially resolves #78.