### PR TITLE
Replace deprecated h2c package with net/http Protocols

### DIFF
--- a/cmds/dutagent/dutagent.go
+++ b/cmds/dutagent/dutagent.go
@@ -9,25 +9,22 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/BlindspotSoftware/dutctl/internal/buildinfo"
 	"github.com/BlindspotSoftware/dutctl/internal/dutagent"
 	"github.com/BlindspotSoftware/dutctl/pkg/dut"
 	"github.com/BlindspotSoftware/dutctl/protobuf/gen/dutctl/v1/dutctlv1connect"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"gopkg.in/yaml.v3"
 
 	pb "github.com/BlindspotSoftware/dutctl/protobuf/gen/dutctl/v1"
@@ -155,6 +152,9 @@ func printInitErr(err error) {
 	log.Print(err)
 }
 
+// readHeaderTimeout bounds how long the server waits to read request headers.
+const readHeaderTimeout = 10 * time.Second
+
 // startRPCService starts the RPC service, that ideally listens for incoming
 // connections forever. It always returns an non-nil error.
 func (agt *agent) startRPCService() error {
@@ -167,12 +167,17 @@ func (agt *agent) startRPCService() error {
 	path, handler := dutctlv1connect.NewDeviceServiceHandler(service)
 	mux.Handle(path, handler)
 
-	//nolint:gosec
-	return http.ListenAndServe(
-		agt.address,
-		// Use h2c so we can serve HTTP/2 without TLS.
-		h2c.NewHandler(mux, &http2.Server{}),
-	)
+	// Serve HTTP/2 without TLS (h2c)
+	srv := &http.Server{
+		Addr:              agt.address,
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+	}
+	srv.Protocols = new(http.Protocols)
+	srv.Protocols.SetHTTP1(true)
+	srv.Protocols.SetUnencryptedHTTP2(true)
+
+	return srv.ListenAndServe()
 }
 
 func (agt *agent) registerWithServer() error {
@@ -211,19 +216,17 @@ func spawnClient(agendURL string) dutctlv1connect.RelayServiceClient {
 
 // TODO: refactor into pkg and reuse in dutctl and dutserver.
 func newInsecureClient() *http.Client {
-	return &http.Client{
-		Transport: &http2.Transport{
-			AllowHTTP: true,
-			DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
-				// If you're also using this client for non-h2c traffic, you may want
-				// to delegate to tls.Dial if the network isn't TCP or the addr isn't
-				// in an allowlist.
+	transport := &http.Transport{}
+	transport.Protocols = new(http.Protocols)
+	transport.Protocols.SetUnencryptedHTTP2(true)
 
-				//nolint:noctx
-				return net.Dial(network, addr)
-			},
-			// TODO: Don't forget timeouts!
-		},
+	return &http.Client{
+		Transport: transport,
+		// TODO: Don't forget timeouts! http.Client.Timeout must not be used here:
+		// it bounds the entire exchange including the response body, which would
+		// abort long-lived streaming RPCs. Instead use per-RPC context deadlines
+		// on unary calls and/or transport timeouts (DialContext,
+		// TLSHandshakeTimeout, ResponseHeaderTimeout, IdleConnTimeout).
 	}
 }
 

--- a/cmds/dutctl/dutctl.go
+++ b/cmds/dutctl/dutctl.go
@@ -7,13 +7,11 @@
 package main
 
 import (
-	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"os"
 
@@ -22,7 +20,6 @@ import (
 	"github.com/BlindspotSoftware/dutctl/internal/output"
 	"github.com/BlindspotSoftware/dutctl/pkg/lock"
 	"github.com/BlindspotSoftware/dutctl/protobuf/gen/dutctl/v1/dutctlv1connect"
-	"golang.org/x/net/http2"
 )
 
 const usageAbstract = `dutctl - The client application of the DUT Control system.
@@ -128,7 +125,6 @@ type application struct {
 
 func (app *application) setupRPCClient() {
 	client := dutctlv1connect.NewDeviceServiceClient(
-		// Instead of http.DefaultClient, use the HTTP/2 protocol without TLS
 		newInsecureClient(),
 		fmt.Sprintf("http://%s", app.serverAddr),
 		connect.WithGRPC(),
@@ -138,19 +134,18 @@ func (app *application) setupRPCClient() {
 }
 
 func newInsecureClient() *http.Client {
-	return &http.Client{
-		Transport: &http2.Transport{
-			AllowHTTP: true,
-			DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
-				// If you're also using this client for non-h2c traffic, you may want
-				// to delegate to tls.Dial if the network isn't TCP or the addr isn't
-				// in an allowlist.
+	// Use the HTTP/2 protocol without TLS (h2c)
+	transport := &http.Transport{}
+	transport.Protocols = new(http.Protocols)
+	transport.Protocols.SetUnencryptedHTTP2(true)
 
-				//nolint:noctx
-				return net.Dial(network, addr)
-			},
-			// Don't forget timeouts!
-		},
+	return &http.Client{
+		Transport: transport,
+		// TODO: Don't forget timeouts! http.Client.Timeout must not be used here:
+		// it bounds the entire exchange including the response body, which would
+		// abort long-lived streaming RPCs. Instead use per-RPC context deadlines
+		// on unary calls and/or transport timeouts (DialContext,
+		// TLSHandshakeTimeout, ResponseHeaderTimeout, IdleConnTimeout).
 	}
 }
 

--- a/cmds/exp/dutserver/dutserver.go
+++ b/cmds/exp/dutserver/dutserver.go
@@ -14,10 +14,9 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/BlindspotSoftware/dutctl/protobuf/gen/dutctl/v1/dutctlv1connect"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
 
 const (
@@ -76,6 +75,9 @@ func (svr *server) watchInterrupt() {
 	}()
 }
 
+// readHeaderTimeout bounds how long the server waits to read request headers.
+const readHeaderTimeout = 10 * time.Second
+
 // startRPCService starts the RPC service, that ideally listens for incoming
 // connections forever. It always returns an non-nil error.
 func (svr *server) startRPCService() error {
@@ -94,12 +96,17 @@ func (svr *server) startRPCService() error {
 	path, handler = dutctlv1connect.NewRelayServiceHandler(service)
 	mux.Handle(path, handler)
 
-	//nolint:gosec
-	return http.ListenAndServe(
-		svr.address,
-		// Use h2c so we can serve HTTP/2 without TLS.
-		h2c.NewHandler(mux, &http2.Server{}),
-	)
+	// Serve HTTP/2 without TLS (h2c)
+	srv := &http.Server{
+		Addr:              svr.address,
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+	}
+	srv.Protocols = new(http.Protocols)
+	srv.Protocols.SetHTTP1(true)
+	srv.Protocols.SetUnencryptedHTTP2(true)
+
+	return srv.ListenAndServe()
 }
 
 // start orchestrates the dutagent execution.

--- a/cmds/exp/dutserver/rpc.go
+++ b/cmds/exp/dutserver/rpc.go
@@ -6,13 +6,11 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"maps"
-	"net"
 	"net/http"
 	"slices"
 	"sync"
@@ -20,7 +18,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/BlindspotSoftware/dutctl/pkg/lock"
 	"github.com/BlindspotSoftware/dutctl/protobuf/gen/dutctl/v1/dutctlv1connect"
-	"golang.org/x/net/http2"
 
 	pb "github.com/BlindspotSoftware/dutctl/protobuf/gen/dutctl/v1"
 )
@@ -390,19 +387,18 @@ func spawnClient(agendURL string) dutctlv1connect.DeviceServiceClient {
 
 // TODO: refactor into pkg and reuse in dutctl and dutserver.
 func newInsecureClient() *http.Client {
-	return &http.Client{
-		Transport: &http2.Transport{
-			AllowHTTP: true,
-			DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
-				// If you're also using this client for non-h2c traffic, you may want
-				// to delegate to tls.Dial if the network isn't TCP or the addr isn't
-				// in an allowlist.
+	// Use the HTTP/2 protocol without TLS (h2c).
+	transport := &http.Transport{}
+	transport.Protocols = new(http.Protocols)
+	transport.Protocols.SetUnencryptedHTTP2(true)
 
-				//nolint:noctx
-				return net.Dial(network, addr)
-			},
-			// TODO: Don't forget timeouts!
-		},
+	return &http.Client{
+		Transport: transport,
+		// TODO: Don't forget timeouts! http.Client.Timeout must not be used here:
+		// it bounds the entire exchange including the response body, which would
+		// abort long-lived streaming RPCs. Instead use per-RPC context deadlines
+		// on unary calls and/or transport timeouts (DialContext,
+		// TLSHandshakeTimeout, ResponseHeaderTimeout, IdleConnTimeout).
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/stianeikeland/go-rpio/v4 v4.6.0
 	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
 	golang.org/x/crypto v0.51.0
-	golang.org/x/net v0.53.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -32,6 +31,7 @@ require (
 	github.com/olekukonko/tablewriter v1.0.9 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.6.1 // indirect
+	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 )


### PR DESCRIPTION
golang.org/x/net/http2/h2c is deprecated; unencrypted HTTP/2 is now supported directly by net/http via the Protocols field (Go 1.24+).

- servers: replace h2c.NewHandler with an http.Server configured via Server.Protocols (HTTP/1 + unencrypted HTTP/2)
- clients: replace http2.Transport (AllowHTTP/DialTLS) with http.Transport configured via Transport.Protocols
- add ReadHeaderTimeout to the servers to mitigate Slowloris (gosec G112), removing the previous //nolint:gosec
- drop the now-unused golang.org/x/net direct dependency (moved to indirect)