### PR TITLE
Scripted send/expect mode for the serial module

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -152,6 +152,7 @@ linters:
         - DeviceServiceClient
         - Formatter
         - gpio
+        - port
 
     lll:
       line-length: 140

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/google/go-cmp v0.7.0
 	github.com/stianeikeland/go-rpio/v4 v4.6.0
-	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
+	go.bug.st/serial v1.7.1
 	golang.org/x/crypto v0.51.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/stianeikeland/go-rpio/v4 v4.6.0 h1:eAJgtw3jTtvn/CqwbC82ntcS+dtzUTgo5q
 github.com/stianeikeland/go-rpio/v4 v4.6.0/go.mod h1:A3GvHxC1Om5zaId+HqB3HKqx4K/AqeckxB7qRjxMK7o=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 h1:UyzmZLoiDWMRywV4DUYb9Fbt8uiOSooupjTq10vpvnU=
-github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+go.bug.st/serial v1.7.1 h1:5aP8wYL0UjEYOVs3oPAGscjaSfRQLHtCvBFXNN/rwtc=
+go.bug.st/serial v1.7.1/go.mod h1:d0MmS16Qt9b1m06yoYRNUXhRRTJV5Qg2S5EKqQtnayQ=
 golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=

--- a/pkg/module/serial/README.md
+++ b/pkg/module/serial/README.md
@@ -2,31 +2,109 @@ The serial package provides a single module:
 
 # Serial
 
-This module establishes a serial connection to the DUT from the _dutagent_ and forwards the output.
+This module connects to the DUT's serial port from the _dutagent_, forwards the
+serial output it reads to the _dutctl_ client, and (optionally) drives a
+scripted `send`/`expect` sequence against the port.
+
+All input is supplied up front as arguments, which makes the module suitable for
+scripts and automated callers. With **no step arguments** it runs in **monitor**
+mode: it streams the serial output until the session is cancelled (or `-t`
+elapses). It does not use an interactive console (`session.Console`) yet.
 
 ```
 ARGUMENTS:
-	[-t <duration>] [<expect>]
+	[-t <duration>] [-eol cr|lf|crlf|none] [-keep-escapes]                 (monitor: stream output)
+	[-t <duration>] [-eol cr|lf|crlf|none] [-keep-escapes] [--] <step>...  (run a step sequence)
 
-If a regex is provided, the module will wait for the regex to match on the serial output, 
-then exit with success.
-If no expect string is provided, the module will read from the serial port until it is terminated by a signal (e.g. Ctrl-C).
-The  expect string supports regular expressions. The optional -t flag specifies the maximum time to wait for the regex to match.
-The regex is passed to the shell as a single argument. The regex must not contain any newlines.
-Quote the regex if it contains spaces or special characters. E.g.: "(?i)hello\s+world!? dutctl"
+	step := expect <regex> | send <data> | send-raw <data>
 ```
 
-The syntax of the regular expressions accepted is the syntax accepted by RE2 and described at https://golang.org/s/re2syntax.
+## Steps
 
-The module is read-only at that time and does not support sending bytes over the serial connection.
+Steps run in order, top to bottom. The run exits with success once all steps
+complete, and with failure on the first `expect` that times out (or on a serial
+error).
 
-See [serial-example-cfg.yml](./serial-example-cfg.yml) for examples. 
+| Step | Behaviour |
+|------|-----------|
+| `expect <re2>` | Wait until the serial output matches the [RE2] regular expression. A plain string is a valid regex that matches itself; escape regex metacharacters (`. $ * + ? ( ) [ ] { } ^ \| \`) to match them literally, e.g. `expect '192\.168\.0\.1'`. |
+| `send <data>` | Write `<data>` followed by the configured line ending (see `-eol`) to the port. |
+| `send-raw <data>` | Write `<data>` verbatim, with no line ending appended. |
+
+`send`/`send-raw` data supports the escapes `\r` `\n` `\t` `\\` and `\xNN`
+(e.g. `\x03` for Ctrl-C). Each step value is a single argument, so quote values
+that contain spaces.
+
+If the last step is a `send`, the module keeps showing output for a moment
+afterwards so the DUT's reply to that final input is visible.
+
+## Monitor mode
+
+Invoking `serial` with **no step arguments** streams the serial output to the
+client until the session is cancelled (Ctrl-C / disconnect), or until `-t`
+elapses — reaching the `-t` deadline in monitor mode is a success. No matching
+is done.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-t <duration>` | Global timeout for the whole run (e.g. `30s`, `3m`). `0` (default) means no timeout. |
+| `-eol cr\|lf\|crlf\|none` | Line ending appended by `send`. Default `cr` (`\r`), which is what serial consoles expect on Enter. |
+| `-keep-escapes` | Keep terminal escape sequences in the output instead of stripping them (e.g. for binary data or exact-byte capture). |
+
+The `--` separator before the steps is optional; it is only needed if a step
+value would otherwise look like a flag.
+
+## Output and matching notes
+
+- Serial output is forwarded to the client whenever the module is reading the
+  port: in monitor mode, while an `expect` is waiting, and (if the last step is
+  a `send`) for a moment afterwards so its reply is visible. Between sends with
+  no following `expect` nothing is read, so nothing is forwarded. Step progress
+  is reported with `--- [n/total] matched/sent … ---` markers.
+- Terminal escape sequences (cursor moves, colour, queries) are stripped from
+  the output before it is shown or matched, so they don't interfere with
+  patterns. Pass `-keep-escapes` to keep them (for binary data or exact-byte
+  capture).
+- Expect matching uses a rolling window of the most recent **64 KiB** of
+  output, so a single pattern cannot span more than that.
+- Match on distinctive markers/prompts rather than `^`/`$` anchors — the rolling
+  buffer has no stable line-start or end-of-text.
+- The DUT may echo what you send, so an `expect` immediately after a `send` can
+  match your own input rather than the device's reply.
+
+The syntax of the regular expressions accepted is the syntax accepted by RE2 and
+described at https://golang.org/s/re2syntax.
+
+## Examples
+
+```
+# Monitor the console (stream until cancelled).
+serial
+
+# Wait for a boot marker, then succeed.
+serial -- expect 'Welcome to'
+
+# Log in and run a command.
+serial -t 60s -- expect 'login:' send root expect 'Password:' send secret expect '# ' send reboot
+
+# Send Ctrl-C, then expect prompt.
+serial -- send-raw '\x03' expect '=>'
+
+# Reboot, then see the output that follows the final send.
+serial -- expect '# ' send reboot
+```
+
+See [serial-example-cfg.yml](./serial-example-cfg.yml) for a configuration
+example.
 
 ## Configuration Options
 
-| Option | Value  | Description                                            |
-|--------|--------|--------------------------------------------------------|
-| port   | string | Hostname or IP address of the DUT                      |
-| baud   | int    | Port number of the SSH server on the DUT (default: 22) |
+| Option | Value  | Description                                                         |
+|--------|--------|---------------------------------------------------------------------|
+| port   | string | Path to the serial device on the dutagent (e.g. `/dev/ttyUSB0`)     |
+| baud   | int    | Baud rate of the serial connection (default: 115200)                |
+| delay  | string | Pause before each send, e.g. `200ms` (default: 50ms; `0s` disables) |
 
-
+[RE2]: https://golang.org/s/re2syntax

--- a/pkg/module/serial/engine.go
+++ b/pkg/module/serial/engine.go
@@ -1,0 +1,346 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package serial
+
+import (
+	"context"
+	"io"
+	"regexp"
+	"time"
+)
+
+// port is the minimal serial-port surface the serial module needs. It is a
+// subset of go.bug.st/serial.Port, so a serial.Port satisfies it directly,
+// while tests can provide a fake.
+type port interface {
+	Read(p []byte) (int, error)
+	Write(p []byte) (int, error)
+	ResetInputBuffer() error
+	Close() error
+}
+
+// matchWindow bounds the number of trailing output bytes the expect matcher
+// keeps in memory. It limits how far back a single regex match may reach; it
+// does NOT cap forwarded output (every byte is teed to the sink regardless).
+// An expect pattern whose match would span more than matchWindow bytes cannot
+// match. 64 KiB is ample for prompts and boot markers.
+const matchWindow = 64 * 1024
+
+// readChunk is the size of a single read from the serial port.
+const readChunk = 4096
+
+// engine drives a serial port for the scripted send/expect mode. It owns a
+// rolling match buffer (never reset on newline) and tees every byte read from
+// the port to an output sink (the client console in scripted mode).
+//
+// The same engine is intended to back a future interactive (session.Console)
+// mode: swap sink for the Console stdout writer and feed write() from the
+// Console stdin reader — the port abstraction and matching logic are shared.
+type engine struct {
+	p    port
+	sink io.Writer
+	buf  []byte
+
+	// filter strips terminal escape sequences from output when true (disabled
+	// by -keep-escapes); remainder carries a partial sequence split across reads.
+	filter    bool
+	remainder []byte
+}
+
+func newEngine(p port, sink io.Writer, filter bool) *engine {
+	return &engine{p: p, sink: sink, buf: make([]byte, 0, readChunk), filter: filter}
+}
+
+// readUntil reads from the port, forwarding every byte to the sink, until re
+// matches the accumulated output or ctx is done (global timeout / cancel).
+// On a match, the matched span and everything before it is consumed from the
+// buffer, so a later expect only sees subsequent output.
+func (e *engine) readUntil(ctx context.Context, pattern *regexp.Regexp) error {
+	readBuf := make([]byte, readChunk)
+
+	for {
+		// Check the whole buffer for a match FIRST, so output a prior step left
+		// behind is honored, and so a match is tested before any trimming (it
+		// can never be split at the trim boundary).
+		if loc := pattern.FindIndex(e.buf); loc != nil {
+			e.buf = e.buf[loc[1]:]
+
+			return nil
+		}
+
+		// No match in the current buffer; bound it before reading more. Safe
+		// here precisely because we just confirmed no completed match exists.
+		e.capBuffer()
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		n, err := e.p.Read(readBuf)
+		if n > 0 {
+			out := e.clean(readBuf[:n])
+			if len(out) > 0 {
+				// Tee: forward to the client, then feed the matcher (re-checked
+				// at the top of the next iteration).
+				_, werr := e.sink.Write(out)
+				if werr != nil {
+					return werr
+				}
+
+				e.buf = append(e.buf, out...)
+			}
+
+			continue
+		}
+
+		// go.bug.st returns (0, nil) on a read timeout — keep waiting and let
+		// the ctx check above enforce the overall deadline. Any real error
+		// (port closed / device gone) ends the step.
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// write sends payload to the port, looping over short writes, then resets the
+// match buffer so the next expect starts from output produced after the send.
+func (e *engine) write(payload []byte) error {
+	for len(payload) > 0 {
+		n, err := e.p.Write(payload)
+		if err != nil {
+			return err
+		}
+
+		payload = payload[n:]
+	}
+
+	e.buf = e.buf[:0]
+
+	return nil
+}
+
+// capBuffer keeps only the trailing matchWindow bytes so memory stays bounded
+// during a long, non-matching stream. Trimming happens only after a failed
+// match check, so it never drops bytes of a match that already completed.
+func (e *engine) capBuffer() {
+	if len(e.buf) > matchWindow {
+		// copy(dst, src) is memmove-safe for the overlapping reslice; this
+		// keeps the tail and lets the head be reused.
+		e.buf = append(e.buf[:0], e.buf[len(e.buf)-matchWindow:]...)
+	}
+}
+
+// pump reads from the port and forwards every byte to the sink until ctx is
+// done (a normal end for a watch/drain, so it returns nil). On a real read
+// error it returns the error, unless swallowReadErr is set — used by the
+// post-send drain, where the device may have rebooted from the final send and
+// the sequence has already completed successfully.
+func (e *engine) pump(ctx context.Context, swallowReadErr bool) error {
+	readBuf := make([]byte, readChunk)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		n, err := e.p.Read(readBuf)
+		if n > 0 {
+			out := e.clean(readBuf[:n])
+			if len(out) > 0 {
+				_, werr := e.sink.Write(out)
+				if werr != nil {
+					return werr
+				}
+			}
+		}
+
+		if err != nil {
+			if swallowReadErr {
+				return nil
+			}
+
+			return err
+		}
+	}
+}
+
+// monitor streams serial output to the sink until ctx is done. It does no
+// matching; the deadline or a client cancel is a normal end, so it returns nil
+// in those cases and only fails on a real read error.
+func (e *engine) monitor(ctx context.Context) error {
+	return e.pump(ctx, false)
+}
+
+// drain forwards serial output for up to d, so the DUT's reply to a final send
+// is visible before the run closes. It is best-effort: a read error (e.g. the
+// device rebooted from that send) ends it without failing the run.
+func (e *engine) drain(ctx context.Context, d time.Duration) error {
+	drainCtx, cancel := context.WithTimeout(ctx, d)
+	defer cancel()
+
+	return e.pump(drainCtx, true)
+}
+
+// escByte is the ASCII escape that begins ANSI/VT escape sequences.
+const escByte = 0x1b
+
+// csiPrefixLen is the length of the CSI prefix "ESC[".
+const csiPrefixLen = 2
+
+// maxRemainder bounds the partial escape sequence carried across reads, so an
+// unterminated sequence cannot grow the buffer without bound.
+const maxRemainder = 4 * readChunk
+
+// ANSI string-sequence terminators.
+const (
+	stByte  = 0x9c // C1 String Terminator
+	belByte = 0x07 // BEL, also terminates an OSC
+)
+
+// CSI byte ranges (ECMA-48): parameter bytes 0x30–0x3f, intermediate bytes
+// 0x20–0x2f, then a single final byte 0x40–0x7e.
+const (
+	csiParamLo = 0x30
+	csiParamHi = 0x3f
+	csiInterLo = 0x20
+	csiInterHi = 0x2f
+	csiFinalLo = 0x40
+	csiFinalHi = 0x7e
+)
+
+// clean strips terminal escape sequences from a read chunk (unless filtering is
+// disabled), reassembling sequences split across reads via remainder.
+func (e *engine) clean(chunk []byte) []byte {
+	if !e.filter {
+		return chunk
+	}
+
+	if len(e.remainder) > 0 {
+		chunk = append(e.remainder, chunk...)
+		e.remainder = nil
+	}
+
+	out := stripEscapes(chunk, &e.remainder)
+
+	if len(e.remainder) > maxRemainder {
+		// An unterminated sequence this long is almost certainly junk; stop
+		// carrying it so the buffer stays bounded. A terminator arriving in a
+		// later chunk may then leak as a stray byte — acceptable for such
+		// pathological input; preceding visible text is never lost.
+		e.remainder = nil
+	}
+
+	return out
+}
+
+// stripEscapes removes ANSI/VT escape sequences from data, including SGR colour
+// — the matched bytes then equal the visible text, so a prompt split by a colour
+// change still matches. An incomplete sequence at the end of data is stored in
+// remainder to be prepended to the next read.
+func stripEscapes(data []byte, remainder *[]byte) []byte {
+	result := make([]byte, 0, len(data))
+	*remainder = nil
+
+	for idx := 0; idx < len(data); idx++ {
+		if data[idx] != escByte {
+			result = append(result, data[idx])
+
+			continue
+		}
+
+		end := seqEnd(data, idx)
+		if end < 0 {
+			// Incomplete sequence — carry it to the next read.
+			*remainder = append([]byte(nil), data[idx:]...)
+
+			return result
+		}
+
+		idx = end // skip the whole sequence; the loop's idx++ moves past it
+	}
+
+	return result
+}
+
+// seqEnd returns the index of the last byte of the escape sequence starting at
+// the ESC byte data[escIdx], or -1 if the sequence is not complete within data.
+func seqEnd(data []byte, escIdx int) int {
+	if escIdx+1 >= len(data) {
+		return -1 // lone ESC at end; the sequence may span reads
+	}
+
+	switch {
+	case isStringSeqIntroducer(data[escIdx+1]):
+		return stringSeqEnd(data, escIdx)
+	case data[escIdx+1] == '[':
+		return csiEnd(data, escIdx)
+	default:
+		return escIdx + 1 // two-byte escape, e.g. "ESC c"
+	}
+}
+
+// isStringSeqIntroducer reports whether b (the byte after ESC) begins an ANSI
+// string sequence: DCS (P), OSC (]), SOS (X), PM (^) or APC (_). These carry
+// terminal queries/responses, never display content.
+func isStringSeqIntroducer(b byte) bool {
+	return b == 'P' || b == ']' || b == 'X' || b == '^' || b == '_'
+}
+
+// csiEnd returns the index of the final byte of the CSI sequence starting at
+// data[escIdx] ("ESC["), or -1 if it is not complete within data.
+func csiEnd(data []byte, escIdx int) int {
+	pos := escIdx + csiPrefixLen
+	for pos < len(data) && data[pos] >= csiParamLo && data[pos] <= csiParamHi {
+		pos++ // parameter bytes
+	}
+
+	for pos < len(data) && data[pos] >= csiInterLo && data[pos] <= csiInterHi {
+		pos++ // intermediate bytes
+	}
+
+	if pos >= len(data) {
+		return -1 // final byte not yet read
+	}
+
+	if data[pos] < csiFinalLo || data[pos] > csiFinalHi {
+		// Not a valid CSI final byte — e.g. a new ESC interrupting the sequence
+		// (a terminal aborts an in-progress CSI on a fresh ESC) or a stray
+		// control byte. Abort and re-scan this byte: drop "ESC[..." up to but
+		// excluding it (the caller does idx = end, then idx++ lands on data[pos]).
+		return pos - 1
+	}
+
+	return pos // final byte (0x40–0x7e)
+}
+
+// stringSeqEnd returns the index of the last byte of the ANSI string sequence
+// starting at data[escIdx], or -1 if it is not terminated within data. It ends
+// at ST ("ESC \" or 0x9c); an OSC may also end at BEL.
+func stringSeqEnd(data []byte, escIdx int) int {
+	osc := data[escIdx+1] == ']'
+
+	for pos := escIdx + csiPrefixLen; pos < len(data); pos++ {
+		switch {
+		case data[pos] == stByte:
+			return pos
+		case osc && data[pos] == belByte:
+			return pos
+		case data[pos] == escByte:
+			if pos+1 >= len(data) {
+				return -1 // ESC at end — the ST may be split across reads
+			}
+
+			if data[pos+1] == '\\' {
+				return pos + 1 // "ESC \" = ST
+			}
+		}
+	}
+
+	return -1
+}

--- a/pkg/module/serial/engine_test.go
+++ b/pkg/module/serial/engine_test.go
@@ -1,0 +1,266 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package serial
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// fakePort is a test double for the port interface.
+//
+// reads is a queue of results returned by successive Read calls; an empty
+// element simulates a (0, nil) read timeout. Once the queue is exhausted, Read
+// returns (0, readErr) — a nil readErr therefore models a port that has gone
+// quiet (perpetual timeout), used to drive timeout tests.
+type fakePort struct {
+	reads      [][]byte
+	readErr    error
+	written    []byte
+	closed     bool
+	resetCount int
+}
+
+func (f *fakePort) Read(p []byte) (int, error) {
+	if len(f.reads) == 0 {
+		return 0, f.readErr
+	}
+
+	chunk := f.reads[0]
+	f.reads = f.reads[1:]
+
+	if len(chunk) == 0 {
+		return 0, nil // simulated timeout tick
+	}
+
+	n := copy(p, chunk)
+	if n < len(chunk) { // push back the remainder for the next Read
+		f.reads = append([][]byte{chunk[n:]}, f.reads...)
+	}
+
+	return n, nil
+}
+
+func (f *fakePort) Write(p []byte) (int, error) {
+	f.written = append(f.written, p...)
+
+	return len(p), nil
+}
+
+func (f *fakePort) ResetInputBuffer() error { f.resetCount++; return nil }
+func (f *fakePort) Close() error            { f.closed = true; return nil }
+
+var errExhausted = errors.New("fake port: reads exhausted")
+
+func TestEngineReadUntilMatchesAcrossReads(t *testing.T) {
+	fp := &fakePort{
+		reads:   [][]byte{[]byte("foo "), []byte("ba"), []byte("r baz")},
+		readErr: errExhausted,
+	}
+	sink := &bytes.Buffer{}
+	eng := newEngine(fp, sink, false)
+
+	if err := eng.readUntil(context.Background(), regexp.MustCompile("bar")); err != nil {
+		t.Fatalf("readUntil: %v", err)
+	}
+
+	if got, want := sink.String(), "foo bar baz"; got != want {
+		t.Errorf("sink = %q, want %q", got, want)
+	}
+
+	if got, want := string(eng.buf), " baz"; got != want {
+		t.Errorf("leftover buf = %q, want %q (match must be consumed through its end)", got, want)
+	}
+}
+
+func TestEngineSequentialExpectsConsumeBuffer(t *testing.T) {
+	// "foobar baz" arrives in a single read; the first expect must consume
+	// through its match and the second must find the already-buffered tail
+	// WITHOUT needing another read.
+	fp := &fakePort{reads: [][]byte{[]byte("foobar baz")}, readErr: errExhausted}
+	eng := newEngine(fp, &bytes.Buffer{}, false)
+
+	if err := eng.readUntil(context.Background(), regexp.MustCompile("bar")); err != nil {
+		t.Fatalf("first expect: %v", err)
+	}
+
+	if err := eng.readUntil(context.Background(), regexp.MustCompile("baz")); err != nil {
+		t.Fatalf("second expect (should match buffered tail without reading): %v", err)
+	}
+}
+
+func TestEngineReadUntilTimeout(t *testing.T) {
+	// One non-matching chunk, then perpetual (0, nil) timeouts.
+	fp := &fakePort{reads: [][]byte{[]byte("nope")}, readErr: nil}
+	eng := newEngine(fp, &bytes.Buffer{}, false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	err := eng.readUntil(ctx, regexp.MustCompile("never"))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestEngineReadUntilPortError(t *testing.T) {
+	fp := &fakePort{reads: nil, readErr: errExhausted}
+	eng := newEngine(fp, &bytes.Buffer{}, false)
+
+	err := eng.readUntil(context.Background(), regexp.MustCompile("x"))
+	if !errors.Is(err, errExhausted) {
+		t.Errorf("err = %v, want errExhausted", err)
+	}
+}
+
+func TestEngineWriteLoopsAndResetsBuffer(t *testing.T) {
+	fp := &fakePort{}
+	eng := newEngine(fp, &bytes.Buffer{}, false)
+	eng.buf = []byte("stale data from a prior expect")
+
+	if err := eng.write([]byte("reboot\r")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got, want := string(fp.written), "reboot\r"; got != want {
+		t.Errorf("written = %q, want %q", got, want)
+	}
+
+	if len(eng.buf) != 0 {
+		t.Errorf("buf not reset after write: %q", eng.buf)
+	}
+}
+
+func TestEngineCapBufferKeepsTail(t *testing.T) {
+	eng := newEngine(&fakePort{}, &bytes.Buffer{}, false)
+	eng.buf = append(bytes.Repeat([]byte("a"), matchWindow+100), []byte("MARK")...)
+
+	eng.capBuffer()
+
+	if len(eng.buf) != matchWindow {
+		t.Errorf("len(buf) = %d, want %d", len(eng.buf), matchWindow)
+	}
+
+	if !bytes.HasSuffix(eng.buf, []byte("MARK")) {
+		t.Errorf("capBuffer dropped the most recent bytes; want suffix %q", "MARK")
+	}
+}
+
+func TestEngineMonitorForwardsUntilCtxDone(t *testing.T) {
+	fp := &fakePort{reads: [][]byte{[]byte("boot log line\n")}} // then quiet (0,nil)
+	sink := &bytes.Buffer{}
+	eng := newEngine(fp, sink, false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	if err := eng.monitor(ctx); err != nil {
+		t.Fatalf("monitor: %v", err)
+	}
+
+	if got, want := sink.String(), "boot log line\n"; got != want {
+		t.Errorf("sink = %q, want %q", got, want)
+	}
+}
+
+func TestEngineMonitorReturnsReadError(t *testing.T) {
+	fp := &fakePort{reads: nil, readErr: errExhausted}
+	eng := newEngine(fp, &bytes.Buffer{}, false)
+
+	if err := eng.monitor(context.Background()); !errors.Is(err, errExhausted) {
+		t.Errorf("monitor err = %v, want errExhausted", err)
+	}
+}
+
+func TestEngineDrainForwardsBestEffort(t *testing.T) {
+	// Drain forwards available output and returns nil even when the read then
+	// errors (e.g. the device rebooted from the final send).
+	fp := &fakePort{reads: [][]byte{[]byte("Rebooting...\n")}, readErr: errExhausted}
+	sink := &bytes.Buffer{}
+	eng := newEngine(fp, sink, false)
+
+	if err := eng.drain(context.Background(), 50*time.Millisecond); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+
+	if got, want := sink.String(), "Rebooting...\n"; got != want {
+		t.Errorf("sink = %q, want %q", got, want)
+	}
+}
+
+func TestStripEscapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantRem string
+	}{
+		{"plain text", "hello world", "hello world", ""},
+		{"sgr colour", "a\x1b[31mred\x1b[0mb", "aredb", ""},
+		{"csi clear screen", "x\x1b[2Jy", "xy", ""},
+		{"csi cursor query", "x\x1b[6ny", "xy", ""},
+		{"osc with bel", "a\x1b]0;title\x07b", "ab", ""},
+		{"dcs with st", "a\x1bPq;data\x1b\\b", "ab", ""},
+		{"two-byte escape", "a\x1bcb", "ab", ""},
+		{"csi interrupted by esc", "a\x1b[1;\x1b[0mb", "ab", ""},
+		{"csi no params then esc", "\x1b[\x1b[31mRED", "RED", ""},
+		{"incomplete csi carried over", "a\x1b[31", "a", "\x1b[31"},
+		{"lone esc at end carried over", "a\x1b", "a", "\x1b"},
+		{"incomplete osc carried over", "a\x1b]0;ti", "a", "\x1b]0;ti"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rem []byte
+
+			got := stripEscapes([]byte(tt.in), &rem)
+			if string(got) != tt.want {
+				t.Errorf("stripEscapes(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+
+			if string(rem) != tt.wantRem {
+				t.Errorf("remainder = %q, want %q", rem, tt.wantRem)
+			}
+		})
+	}
+}
+
+func TestEngineCleanReassemblesSplitSequence(t *testing.T) {
+	eng := newEngine(&fakePort{}, &bytes.Buffer{}, true)
+
+	out1 := eng.clean([]byte("a\x1b[3")) // incomplete CSI, tail carried over
+	out2 := eng.clean([]byte("2mb"))     // completes the sequence
+
+	if got := string(out1) + string(out2); got != "ab" {
+		t.Errorf("split filter = %q, want %q", got, "ab")
+	}
+}
+
+func TestEngineCleanDisabledPassesThrough(t *testing.T) {
+	eng := newEngine(&fakePort{}, &bytes.Buffer{}, false)
+
+	in := []byte("a\x1b[31mb")
+	if got := eng.clean(in); string(got) != string(in) {
+		t.Errorf("clean with filtering off = %q, want unchanged %q", got, in)
+	}
+}
+
+func TestEngineReadUntilFiltersEscapes(t *testing.T) {
+	fp := &fakePort{reads: [][]byte{[]byte("\x1b[32mlogin:\x1b[0m ")}, readErr: errExhausted}
+	sink := &bytes.Buffer{}
+	eng := newEngine(fp, sink, true)
+
+	if err := eng.readUntil(context.Background(), regexp.MustCompile("login:")); err != nil {
+		t.Fatalf("readUntil: %v", err)
+	}
+
+	if got, want := sink.String(), "login: "; got != want {
+		t.Errorf("sink = %q, want %q (escapes stripped)", got, want)
+	}
+}

--- a/pkg/module/serial/serial-example-cfg.yml
+++ b/pkg/module/serial/serial-example-cfg.yml
@@ -5,11 +5,13 @@ devices:
     cmds:
       serial:
         desc: |
-          Basic demo of the Serial module: After the DUT is powered on, use Serial
-          as the passthrough module to wait for magic strings in the DUT's boot log.
+          Demo of the Serial module as a passthrough module: the client supplies
+          the send/expect script at runtime, e.g.
+            dutctl server serial -t 60s -- expect 'login:' send root expect '# '
         uses:
           - module: serial
             passthrough: true
             with:
               port: /tmp/ttyS0
-              baudrate: 115200
+              baud: 115200
+              delay: 50ms # optional: pause before each send (default 50ms; "0s" disables)

--- a/pkg/module/serial/serial.go
+++ b/pkg/module/serial/serial.go
@@ -2,23 +2,20 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package serial provides a dutagent module that listens on a defined COM port.
+// Package serial provides a dutagent module that runs a scripted send/expect
+// sequence against a DUT's serial port.
 package serial
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"flag"
 	"fmt"
-	"io"
 	"log"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/BlindspotSoftware/dutctl/pkg/module"
-	"github.com/tarm/serial"
+	"go.bug.st/serial"
 )
 
 func init() {
@@ -31,38 +28,110 @@ func init() {
 // DefaultBaudRate is the default baud rate for the serial connection.
 const DefaultBaudRate = 115200
 
-// Serial is a module that forwards the serial output of a connected DUT to the dutctl client.
-// It is non-interactive and does not support stdin yet.
-type Serial struct {
-	Port string // Port is the path to the serial device on the dutagent.
-	Baud int    // Baud is the baud rate of the serial device. Is unset, DefaultBaudRate is used.
+// readTimeout is how long a single port read blocks before returning so the
+// loop can re-check the context. It bounds how promptly the global timeout and
+// cancellation are honored.
+const readTimeout = 100 * time.Millisecond
 
-	expect  *regexp.Regexp // expect is a pattern to match against the serial output.
-	timeout time.Duration  // timeout is the maximum time to wait for the expect pattern to match.
+// defaultDelay is the pause applied before each send when no Delay is
+// configured. It makes sends robust against consoles that present a prompt
+// slightly before the tty is ready to read; configure delay "0s" to disable.
+const defaultDelay = 50 * time.Millisecond
+
+// sendDrain is how long the module keeps reading after a sequence whose last
+// step is a send, so the DUT's reply to that final input is visible before the
+// connection closes.
+const sendDrain = time.Second
+
+// portOpener opens a serial device. It is the injection point that lets tests
+// substitute a fake port for the real hardware.
+type portOpener func(name string, baud int) (port, error)
+
+// Serial observes the DUT's serial output and runs a scripted sequence of
+// send/expect steps against the serial port.
+//
+// The module is non-interactive: all input is supplied up front as arguments,
+// which makes it suitable for scripts and automated callers.
+type Serial struct {
+	Port  string // Port is the path to the serial device on the dutagent.
+	Baud  int    // Baud is the baud rate of the serial device. If unset, DefaultBaudRate is used.
+	Delay string // Delay is the pause before each send (e.g. "200ms") to pace input. Default 50ms; "0s" disables.
+
+	delay time.Duration // delay is the parsed Delay, applied before each send.
+
+	// drainTimeout overrides the post-send drain window; 0 uses sendDrain. It
+	// exists so tests can shorten the drain; production leaves it 0.
+	drainTimeout time.Duration
+
+	// open opens the serial port. It defaults to defaultOpenPort in Run; tests
+	// set it to a fake. Opening happens per Run, never on the struct.
+	open portOpener
 }
 
 // Ensure implementing the Module interface.
 var _ module.Module = &Serial{}
 
-const abstract = `Serial connection to the DUT
+const abstract = `Scripted serial connection to the DUT
 `
 
 const usage = `
 ARGUMENTS:
-	[-t <duration>] [<expect>]
+	[-t <duration>] [-eol cr|lf|crlf|none] [-keep-escapes]                 (monitor: stream output)
+	[-t <duration>] [-eol cr|lf|crlf|none] [-keep-escapes] [--] <step>...  (run a step sequence)
+
+	step := expect <regex> | send <data> | send-raw <data>
 
 `
 
 const description = `
-The serial connection is read-only and does not support stdin yet.
-If a regex is provided, the module will wait for the regex to match on the serial output, 
-then exit with success. If no expect string is provided, the module will read from the serial port
-until it is terminated by a signal (e.g. Ctrl-C).
-The  expect string supports regular expressions according to [1].
-The optional -t flag specifies the maximum time to wait for the regex to match.
-Quote the expect string if it contains spaces or special characters. E.g.: "(?i)hello\s+world!? dutctl"
+The serial module automates interaction with the DUT's serial console. All
+input is provided up front as arguments, so it suits scripts and automated
+callers.
 
-[1] https://golang.org/s/re2syntax.
+With no steps it runs in MONITOR mode: it streams the serial output to the
+client until the session is cancelled, or until -t elapses (a success). With
+one or more steps it runs them in order (see below). Serial output is forwarded
+to the client in monitor mode, while waiting for an expect, and (if the last
+step is a send) for a moment afterwards so its reply is visible.
+
+STEPS (executed in order; the run fails on the first expect that times out):
+	expect <regex>   Wait until the serial output matches the RE2 regular
+	                 expression [1]. A plain string is a valid regex that
+	                 matches itself; escape regex meta characters
+	                 (. $ * + ? ( ) [ ] { } ^ | \) to match them literally,
+	                 e.g. expect '192\.168\.0\.1'.
+	send <data>      Write <data> followed by the configured line ending
+	                 (see -eol) to the port.
+	send-raw <data>  Write <data> verbatim, with no line ending appended.
+
+send / send-raw data supports the escapes \r \n \t \\ and \xNN (e.g. \x03 for
+Ctrl-C). Each step value is one argument, so quote values containing spaces.
+
+If the last step is a send, the module keeps showing output for a moment
+afterwards so the DUT's reply to that final input is visible.
+
+FLAGS (before the steps):
+	-t <duration>          Global timeout for the whole run (e.g. 30s, 3m).
+	                       0 (default) means no timeout.
+	-eol cr|lf|crlf|none   Line ending appended by 'send'. Default: cr ('\r'),
+	                       which is what serial consoles expect on Enter.
+	-keep-escapes          Keep terminal escape sequences (cursor moves, colour,
+	                       queries) instead of stripping them from the output.
+
+Terminal escape sequences (cursor moves, colour, queries) are stripped from the
+output before it is shown or matched, unless -keep-escapes is given. Expect
+matching uses a rolling window of the most recent 64 KiB of output, so a single
+pattern cannot span more than that. Match on distinctive markers/prompts
+rather than '^'/'$' anchors. Note the DUT may echo what you send, so an expect
+right after a send can match your own input rather than the device's reply.
+
+EXAMPLES:
+	monitor the console:            (no arguments)
+	wait for a boot marker:         -- expect 'Welcome to'
+	login then run a command:       -- expect 'login:' send root expect '# ' send reboot
+	send Ctrl-C then expect shell:  -- send-raw '\x03' expect '$ '
+
+[1] https://golang.org/s/re2syntax
 `
 
 func (s *Serial) Help() string {
@@ -71,7 +140,7 @@ func (s *Serial) Help() string {
 	help := strings.Builder{}
 	help.WriteString(abstract)
 	help.WriteString(usage)
-	help.WriteString(fmt.Sprintf("Configured COM port is  %q with baud rate %d.\n", s.Port, s.Baud))
+	fmt.Fprintf(&help, "Configured COM port is %q with baud rate %d.\n", s.Port, s.Baud)
 	help.WriteString(description)
 
 	return help.String()
@@ -88,6 +157,17 @@ func (s *Serial) Init() error {
 		s.Baud = DefaultBaudRate
 	}
 
+	s.delay = defaultDelay
+
+	if s.Delay != "" {
+		parsed, err := time.ParseDuration(s.Delay)
+		if err != nil {
+			return fmt.Errorf("invalid delay %q: %w", s.Delay, err)
+		}
+
+		s.delay = parsed
+	}
+
 	// Note: We don't open the port here to allow dutagent to start
 	// even if the serial device is not yet available (e.g., powered off).
 	// The port will be opened when Run() is called.
@@ -98,146 +178,207 @@ func (s *Serial) Init() error {
 func (s *Serial) Deinit() error {
 	log.Println("serial module: Deinit called")
 
+	// Nothing to clean up: the port is opened and closed within each Run
+	// (see Run's defer), never held on the struct between runs.
 	return nil
 }
 
-//nolint:cyclop,funlen,gocognit
+// defaultOpenPort is the default portOpener; it opens a real serial device.
+func defaultOpenPort(name string, baud int) (port, error) {
+	serialPort, err := serial.Open(name, &serial.Mode{BaudRate: baud})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open serial port %s: %w", name, err)
+	}
+
+	// Short read timeout so the read loop stays responsive to context
+	// cancellation; a timed-out read returns (0, nil), not an error.
+	err = serialPort.SetReadTimeout(readTimeout)
+	if err != nil {
+		_ = serialPort.Close()
+
+		return nil, fmt.Errorf("failed to set read timeout on %s: %w", name, err)
+	}
+
+	return serialPort, nil
+}
+
+//nolint:cyclop,funlen // monitor/sequence dispatch with pacing and drain; the branch count is inherent
 func (s *Serial) Run(ctx context.Context, session module.Session, args ...string) error {
 	log.Println("serial module: Run called")
 
-	err := s.evalArgs(args)
+	// Parse into LOCAL state every Run — the module instance is shared and
+	// reused across RPCs, so nothing per-run may live on the struct.
+	cfg, err := parseArgs(args)
 	if err != nil {
 		return err
 	}
 
-	port, err := s.openPort()
+	opener := s.open
+	if opener == nil {
+		opener = defaultOpenPort
+	}
+
+	serialPort, err := opener(s.Port, s.Baud)
 	if err != nil {
 		return err
 	}
-	defer port.Close()
+	defer serialPort.Close()
 
 	// Discard any stale bytes left in the kernel/driver RX buffer from a
-	// previous session, otherwise the user sees data from the last boot.
-	err = port.Flush()
+	// previous session, otherwise a step could match data from the last boot.
+	err = serialPort.ResetInputBuffer()
 	if err != nil {
-		log.Printf("serial module: flush failed: %v", err)
+		log.Printf("serial module: reset input buffer failed: %v", err)
 	}
 
 	log.Printf("serial module: connected to %s at %d baud", s.Port, s.Baud)
-	session.Print(fmt.Sprintf("--- Connected to %s at %d baud ---\n", s.Port, s.Baud))
 
-	var cancel context.CancelFunc
+	clientOut := newClientWriter(session)
+	clientOut.markerf("--- Connected to %s at %d baud ---\n", s.Port, s.Baud)
 
-	if s.timeout > 0 {
-		log.Printf("serial module: setting timeout of %s", s.timeout)
-		ctx, cancel = context.WithTimeout(ctx, s.timeout)
+	// loopCtx carries the per-sequence deadline (-t). The original ctx is kept
+	// for the post-send drain so the drain gets its own full window.
+	loopCtx := ctx
+
+	if cfg.timeout > 0 {
+		var cancel context.CancelFunc
+
+		log.Printf("serial module: setting global timeout of %s", cfg.timeout)
+		loopCtx, cancel = context.WithTimeout(ctx, cfg.timeout)
 
 		defer cancel()
 	}
 
-	const bufferSize = 4096
+	eng := newEngine(serialPort, clientOut, !cfg.keepEscapes)
 
-	readBuffer := make([]byte, bufferSize)
-	lineBuffer := &bytes.Buffer{}
+	// Monitor mode: no steps — stream the console until cancelled or -t elapses.
+	if len(cfg.steps) == 0 {
+		log.Println("serial module: monitor mode; streaming until cancelled")
 
-	for {
-		select {
-		case <-ctx.Done():
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				session.Print("\n--- Timeout reached, no match found ---\n")
-
-				return fmt.Errorf("timeout of %s reached, pattern %q not found", s.timeout, s.expect)
-			}
-
-			session.Print("\n--- Connection closed ---\n")
-
-			return ctx.Err()
-		default:
-			sbytes, err := port.Read(readBuffer)
-			if err != nil {
-				// Ignore timeout errors as these are expected with the read timeout config
-				if err != io.EOF && !strings.Contains(err.Error(), "timeout") {
-					return fmt.Errorf("error reading from serial port: %w", err)
-				}
-
-				continue
-			}
-
-			if sbytes == 0 {
-				continue
-			}
-
-			// Forward bytes to the client immediately so partial lines are
-			// not held back waiting for a newline from the DUT.
-			session.Print(string(readBuffer[:sbytes]))
-
-			if s.expect == nil {
-				continue
-			}
-
-			// Process the data read character by character
-			for i := range sbytes {
-				b := readBuffer[i]
-				lineBuffer.WriteByte(b)
-
-				// If we reach a newline or a buffer limit, process the line
-				if b == '\n' || lineBuffer.Len() >= 1024 {
-					line := lineBuffer.String()
-
-					// Check for regex match if we have one
-					if s.expect.MatchString(line) {
-						session.Print("\n--- Pattern matched, connection closed ---\n")
-
-						return nil // Success - pattern found
-					}
-
-					lineBuffer.Reset()
-				}
-			}
-		}
-	}
-}
-
-func (s *Serial) evalArgs(args []string) error {
-	fs := flag.NewFlagSet("serial", flag.ContinueOnError)
-	fs.SetOutput(io.Discard) // Suppress default error output
-	fs.DurationVar(&s.timeout, "t", 0, "timeout duration (e.g. 3m, 30s)")
-
-	err := fs.Parse(args)
-	if err != nil {
-		return fmt.Errorf("failed to parse arguments: %w", err)
-	}
-
-	// Reset expect so a previous pattern does not carry over into the next run.
-	s.expect = nil
-
-	// Get the expect string if provided (args after flags)
-	if fs.NArg() > 0 {
-		expectPattern := fs.Arg(0)
-		log.Printf("serial module: Will wait for pattern: %q", expectPattern)
-
-		s.expect, err = regexp.Compile(expectPattern)
+		err = eng.monitor(loopCtx)
 		if err != nil {
-			return fmt.Errorf("invalid regular expression: %w", err)
+			return fmt.Errorf("monitor: %w", err)
+		}
+
+		clientOut.markerf("--- Connection closed ---\n")
+
+		return nil
+	}
+
+	total := len(cfg.steps)
+
+	for idx, curStep := range cfg.steps {
+		switch curStep.kind {
+		case stepExpect:
+			err = eng.readUntil(loopCtx, curStep.expect)
+			if err != nil {
+				return stepError(idx, curStep, cfg.timeout, err)
+			}
+
+			clientOut.markerf("--- [%d/%d] matched %q ---\n", idx+1, total, curStep.label())
+		case stepSend, stepSendRaw:
+			// Pace input: pause before each send (interruptible by the deadline).
+			err = sleepCtx(loopCtx, s.delay)
+			if err != nil {
+				return fmt.Errorf("step %d (send %q): %w", idx+1, curStep.label(), err)
+			}
+
+			err = eng.write(curStep.payload)
+			if err != nil {
+				return fmt.Errorf("step %d (send %q): %w", idx+1, curStep.label(), err)
+			}
+
+			clientOut.markerf("--- [%d/%d] sent %q ---\n", idx+1, total, curStep.label())
 		}
 	}
+
+	// If the sequence ended on a send, drain briefly so the DUT's reply to the
+	// final input is visible. Uses the original ctx (its own window).
+	if cfg.steps[total-1].kind != stepExpect {
+		drainFor := sendDrain
+		if s.drainTimeout > 0 {
+			drainFor = s.drainTimeout
+		}
+
+		err = eng.drain(ctx, drainFor)
+		if err != nil {
+			return fmt.Errorf("draining after final send: %w", err)
+		}
+	}
+
+	clientOut.markerf("--- Script completed ---\n")
 
 	return nil
 }
 
-const readTimeout = 100 * time.Millisecond
-
-func (s *Serial) openPort() (*serial.Port, error) {
-	config := &serial.Config{
-		Name:        s.Port,
-		Baud:        s.Baud,
-		ReadTimeout: readTimeout, // Short timeout for responsive context checking
+// sleepCtx pauses for d, returning ctx.Err() if ctx is done first. A
+// non-positive d returns nil immediately.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
 	}
 
-	port, err := serial.OpenPort(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open serial port %s: %w", s.Port, err)
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// stepError annotates an expect failure with the step number and pattern, and
+// gives a clear message for the common timeout/cancellation cases.
+func stepError(idx int, failedStep step, timeout time.Duration, err error) error {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded) && timeout > 0:
+		return fmt.Errorf("step %d (expect %q): timeout of %s reached without match", idx+1, failedStep.label(), timeout)
+	case errors.Is(err, context.DeadlineExceeded):
+		return fmt.Errorf("step %d (expect %q): deadline reached without match", idx+1, failedStep.label())
+	case errors.Is(err, context.Canceled):
+		return fmt.Errorf("step %d (expect %q): canceled", idx+1, failedStep.label())
+	default:
+		return fmt.Errorf("step %d (expect %q): %w", idx+1, failedStep.label(), err)
+	}
+}
+
+// clientWriter forwards serial output to the client (it is the engine's output
+// sink) and tracks whether the stream is at the start of a line. Status lines
+// go through markerf, which inserts a newline first when the preceding output
+// (e.g. a prompt with no trailing newline) did not end one — so every marker
+// lands on its own line.
+//
+// A future interactive mode would instead use the stdout writer from
+// session.Console().
+type clientWriter struct {
+	session     module.Session
+	atLineStart bool
+}
+
+func newClientWriter(session module.Session) *clientWriter {
+	return &clientWriter{session: session, atLineStart: true}
+}
+
+func (w *clientWriter) Write(p []byte) (int, error) {
+	if len(p) > 0 {
+		w.session.Print(string(p))
+		w.atLineStart = p[len(p)-1] == '\n'
 	}
 
-	return port, nil
+	return len(p), nil
+}
+
+// markerf writes a status line, prefixing a newline when the previous output
+// did not end one, then tracking whether this line left the stream at a line
+// start.
+func (w *clientWriter) markerf(format string, args ...any) {
+	if !w.atLineStart {
+		w.session.Print("\n")
+	}
+
+	msg := fmt.Sprintf(format, args...)
+	w.session.Print(msg)
+	w.atLineStart = len(msg) > 0 && msg[len(msg)-1] == '\n'
 }

--- a/pkg/module/serial/serial_test.go
+++ b/pkg/module/serial/serial_test.go
@@ -1,0 +1,271 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package serial
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BlindspotSoftware/dutctl/internal/test/mock"
+)
+
+// recordingSession is a module.Session that accumulates the client-facing text,
+// so tests can assert exactly what was forwarded.
+type recordingSession struct {
+	mock.Session
+	out strings.Builder
+}
+
+func (r *recordingSession) Print(a ...any)            { r.out.WriteString(fmt.Sprint(a...)) }
+func (r *recordingSession) Printf(f string, a ...any) { r.out.WriteString(fmt.Sprintf(f, a...)) }
+func (r *recordingSession) Println(a ...any)          { r.out.WriteString(fmt.Sprintln(a...)) }
+
+// newSerialWithPort builds a Serial whose port opener returns fp, so tests run
+// against a fake port instead of real hardware. The post-send drain is
+// shortened so send-ending sequences don't make the suite wait a full second.
+func newSerialWithPort(fp *fakePort) *Serial {
+	return &Serial{
+		Port:         "/dev/fake",
+		Baud:         115200,
+		drainTimeout: 10 * time.Millisecond,
+		open:         func(_ string, _ int) (port, error) { return fp, nil },
+	}
+}
+
+func TestSerialRunScenarios(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		reads       [][]byte
+		wantErr     bool
+		wantWritten string
+	}{
+		{
+			name:        "send wait send",
+			args:        []string{"-t", "1s", "--", "send", "foo", "expect", "bar", "send", "foobar"},
+			reads:       [][]byte{[]byte("xx bar yy")},
+			wantWritten: "foo\rfoobar\r",
+		},
+		{
+			name:  "expect only",
+			args:  []string{"--", "expect", "foo"},
+			reads: [][]byte{[]byte("...foo...")},
+		},
+		{
+			name:        "expect send expect",
+			args:        []string{"--", "expect", "foo", "send", "bar", "expect", "1"},
+			reads:       [][]byte{[]byte("foo"), []byte("1")},
+			wantWritten: "bar\r",
+		},
+		{
+			name:        "send send",
+			args:        []string{"--", "send", "foo", "send", "bar"},
+			reads:       nil,
+			wantWritten: "foo\rbar\r",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fp := &fakePort{reads: tt.reads} // readErr nil => quiet port after exhaustion
+			s := newSerialWithPort(fp)
+
+			err := s.Run(context.Background(), &mock.Session{}, tt.args...)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Run err = %v, wantErr = %v", err, tt.wantErr)
+			}
+
+			if got := string(fp.written); got != tt.wantWritten {
+				t.Errorf("written = %q, want %q", got, tt.wantWritten)
+			}
+
+			if !fp.closed {
+				t.Error("port was not closed")
+			}
+
+			if fp.resetCount != 1 {
+				t.Errorf("ResetInputBuffer called %d times, want 1", fp.resetCount)
+			}
+		})
+	}
+}
+
+func TestSerialRunTimeoutNamesStep(t *testing.T) {
+	fp := &fakePort{reads: [][]byte{[]byte("boot log without the marker")}} // then quiet
+	s := newSerialWithPort(fp)
+
+	err := s.Run(context.Background(), &mock.Session{},
+		"-t", "30ms", "--", "send", "go", "expect", "PROMPT")
+	if err == nil {
+		t.Fatal("Run = nil error, want timeout error")
+	}
+
+	// The failing step is the 2nd one (expect PROMPT) and the error must name it.
+	if !strings.Contains(err.Error(), "step 2") || !strings.Contains(err.Error(), "PROMPT") {
+		t.Errorf("error %q should identify step 2 and the pattern PROMPT", err)
+	}
+
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("error %q should mention timeout", err)
+	}
+}
+
+func TestSerialRunBadArgs(t *testing.T) {
+	s := newSerialWithPort(&fakePort{})
+
+	if err := s.Run(context.Background(), &mock.Session{}, "--", "bogus", "x"); err == nil {
+		t.Error("Run with unknown verb = nil error, want error")
+	}
+}
+
+func TestSerialInit(t *testing.T) {
+	t.Run("missing port", func(t *testing.T) {
+		s := &Serial{}
+		if err := s.Init(); err == nil {
+			t.Error("Init with empty Port = nil error, want error")
+		}
+	})
+
+	t.Run("defaults baud", func(t *testing.T) {
+		s := &Serial{Port: "/dev/fake"}
+		if err := s.Init(); err != nil {
+			t.Fatalf("Init: %v", err)
+		}
+
+		if s.Baud != DefaultBaudRate {
+			t.Errorf("Baud = %d, want default %d", s.Baud, DefaultBaudRate)
+		}
+	})
+}
+
+func TestSerialInitDelay(t *testing.T) {
+	tests := []struct {
+		name    string
+		delay   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"default when unset", "", defaultDelay, false},
+		{"explicit", "200ms", 200 * time.Millisecond, false},
+		{"zero disables", "0s", 0, false},
+		{"invalid", "fast", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Serial{Port: "/dev/fake", Delay: tt.delay}
+
+			err := s.Init()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Init err = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr && s.delay != tt.want {
+				t.Errorf("delay = %v, want %v", s.delay, tt.want)
+			}
+		})
+	}
+}
+
+func TestSleepCtx(t *testing.T) {
+	if err := sleepCtx(context.Background(), 0); err != nil {
+		t.Errorf("sleepCtx(0) = %v, want nil", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := sleepCtx(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Errorf("sleepCtx(cancelled) = %v, want context.Canceled", err)
+	}
+}
+
+func TestSerialRunMonitor(t *testing.T) {
+	fp := &fakePort{reads: [][]byte{[]byte("watching...\n")}} // then quiet
+	s := newSerialWithPort(fp)
+	sess := &mock.Session{}
+
+	// No step args => monitor mode; a short -t ends the stream with success.
+	err := s.Run(context.Background(), sess, "-t", "30ms")
+	if err != nil {
+		t.Fatalf("monitor Run = %v, want nil", err)
+	}
+
+	if !fp.closed {
+		t.Error("port was not closed")
+	}
+
+	if sess.PrintText != "--- Connection closed ---\n" {
+		t.Errorf("last client message = %q, want the connection-closed banner", sess.PrintText)
+	}
+}
+
+func TestSerialRunTrailingSendDrain(t *testing.T) {
+	// Sequence ends on a send; the DUT's reply arrives during the drain.
+	fp := &fakePort{reads: [][]byte{[]byte("Rebooting now...\n")}}
+	s := newSerialWithPort(fp) // 10ms drain
+
+	err := s.Run(context.Background(), &mock.Session{}, "--", "send", "reboot")
+	if err != nil {
+		t.Fatalf("Run = %v, want nil", err)
+	}
+
+	if got, want := string(fp.written), "reboot\r"; got != want {
+		t.Errorf("written = %q, want %q", got, want)
+	}
+
+	if len(fp.reads) != 0 {
+		t.Errorf("drain did not consume the queued reply; %d reads left", len(fp.reads))
+	}
+}
+
+func TestSerialRunFiltersEscapes(t *testing.T) {
+	// A colour reset splits the prompt ("#\x1b[0m "); filtering (the default)
+	// strips it so "# " is contiguous and the expect matches.
+	fp := &fakePort{reads: [][]byte{[]byte("#\x1b[0m ")}}
+	s := newSerialWithPort(fp)
+
+	err := s.Run(context.Background(), &mock.Session{}, "-t", "1s", "--", "expect", "# ")
+	if err != nil {
+		t.Fatalf("Run = %v, want nil (escapes stripped so '# ' matches)", err)
+	}
+}
+
+func TestSerialRunKeepEscapes(t *testing.T) {
+	// With -keep-escapes the colour reset is kept, so "# " is not contiguous and
+	// the expect cannot match before the timeout.
+	fp := &fakePort{reads: [][]byte{[]byte("#\x1b[0m ")}} // then quiet
+	s := newSerialWithPort(fp)
+
+	err := s.Run(context.Background(), &mock.Session{}, "-keep-escapes", "-t", "30ms", "--", "expect", "# ")
+	if err == nil {
+		t.Fatal("Run = nil, want timeout (-keep-escapes keeps the escape so '# ' is not contiguous)")
+	}
+}
+
+func TestClientWriterMarkersOnOwnLine(t *testing.T) {
+	rec := &recordingSession{}
+	cw := newClientWriter(rec)
+
+	_, _ = cw.Write([]byte("login: ")) // prompt, no trailing newline
+	cw.markerf("--- [1/2] matched %q ---\n", "login:")
+	cw.markerf("--- [2/2] sent %q ---\n", "root") // already at line start: no blank line
+	_, _ = cw.Write([]byte("output\n"))           // ends with a newline
+	cw.markerf("--- done ---\n")
+
+	want := "login: \n" +
+		"--- [1/2] matched \"login:\" ---\n" +
+		"--- [2/2] sent \"root\" ---\n" +
+		"output\n" +
+		"--- done ---\n"
+
+	if got := rec.out.String(); got != want {
+		t.Errorf("client output:\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/pkg/module/serial/step.go
+++ b/pkg/module/serial/step.go
@@ -1,0 +1,226 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package serial
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// stepKind identifies the operation a step performs.
+type stepKind int
+
+const (
+	stepExpect stepKind = iota
+	stepSend
+	stepSendRaw
+)
+
+// step is one operation in a scripted send/expect sequence.
+type step struct {
+	kind    stepKind
+	expect  *regexp.Regexp // set for stepExpect
+	payload []byte         // set for stepSend / stepSendRaw (escapes decoded; EOL appended for stepSend)
+	src     string         // original argument; shown (truncated) via label() in markers and errors
+	// timeout time.Duration // FUTURE: per-step timeout override
+}
+
+// maxLabelLen bounds how many runes of a step's source argument appear in
+// progress markers and error messages, so a long pattern or payload does not
+// bloat the log line.
+const maxLabelLen = 20
+
+// label returns the step's source argument, truncated for display in progress
+// markers and error messages.
+func (s step) label() string {
+	return truncate(s.src, maxLabelLen)
+}
+
+// truncate shortens text to at most limit runes, appending an ellipsis when it
+// had to cut. It counts runes (not bytes) so it never splits a multi-byte rune.
+func truncate(text string, limit int) string {
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+
+	return string(runes[:limit]) + "..."
+}
+
+// scriptConfig is the parsed result of a serial module invocation: the global
+// flags plus the ordered step sequence.
+type scriptConfig struct {
+	timeout     time.Duration
+	keepEscapes bool
+	steps       []step
+}
+
+const defaultEOL = "cr"
+
+// parseArgs parses the module arguments: the leading flags (-t, -eol) followed
+// by the step sequence (optionally after a "--" separator). It returns local
+// state only — nothing is stored on the module, which is reused across runs.
+func parseArgs(args []string) (scriptConfig, error) {
+	fs := flag.NewFlagSet("serial", flag.ContinueOnError)
+	fs.SetOutput(io.Discard) // Suppress default error output.
+
+	var (
+		timeout     time.Duration
+		eolName     string
+		keepEscapes bool
+	)
+
+	fs.DurationVar(&timeout, "t", 0, "global timeout for the whole run (e.g. 30s, 3m); 0 = no timeout")
+	fs.StringVar(&eolName, "eol", defaultEOL, "line ending appended by 'send': cr|lf|crlf|none")
+	fs.BoolVar(&keepEscapes, "keep-escapes", false, "keep terminal escape sequences in the output instead of stripping them")
+
+	err := fs.Parse(args)
+	if err != nil {
+		return scriptConfig{}, fmt.Errorf("failed to parse arguments: %w", err)
+	}
+
+	eol, err := resolveEOL(eolName)
+	if err != nil {
+		return scriptConfig{}, err
+	}
+
+	steps, err := parseSteps(fs.Args(), eol)
+	if err != nil {
+		return scriptConfig{}, err
+	}
+
+	return scriptConfig{timeout: timeout, keepEscapes: keepEscapes, steps: steps}, nil
+}
+
+// resolveEOL maps the -eol flag value to the bytes appended by a 'send' step.
+func resolveEOL(name string) ([]byte, error) {
+	switch strings.ToLower(name) {
+	case "cr":
+		return []byte("\r"), nil
+	case "lf":
+		return []byte("\n"), nil
+	case "crlf":
+		return []byte("\r\n"), nil
+	case "none":
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("invalid -eol %q: want cr, lf, crlf, or none", name)
+	}
+}
+
+// parseSteps scans the verb token stream left-to-right into ordered steps.
+// Each verb consumes exactly the next token as its argument.
+func parseSteps(tokens []string, eol []byte) ([]step, error) {
+	var steps []step
+
+	for idx := 0; idx < len(tokens); {
+		verb := tokens[idx]
+		idx++
+
+		switch verb {
+		case "expect":
+			if idx >= len(tokens) {
+				return nil, fmt.Errorf("%q requires a pattern argument", verb)
+			}
+
+			pat := tokens[idx]
+			idx++
+
+			re, err := regexp.Compile(pat)
+			if err != nil {
+				return nil, fmt.Errorf("invalid regular expression %q: %w", pat, err)
+			}
+
+			steps = append(steps, step{kind: stepExpect, expect: re, src: pat})
+		case "send", "send-raw":
+			if idx >= len(tokens) {
+				return nil, fmt.Errorf("%q requires a data argument", verb)
+			}
+
+			raw := tokens[idx]
+			idx++
+
+			data, err := decodeEscapes(raw)
+			if err != nil {
+				return nil, fmt.Errorf("invalid data %q: %w", raw, err)
+			}
+
+			kind := stepSend
+			if verb == "send-raw" {
+				kind = stepSendRaw
+			} else {
+				data = append(data, eol...)
+			}
+
+			steps = append(steps, step{kind: kind, payload: data, src: raw})
+		default:
+			return nil, fmt.Errorf("unknown step verb %q (want expect, send, or send-raw)", verb)
+		}
+	}
+
+	// An empty sequence is valid: it selects monitor mode (stream until
+	// cancelled). Run handles len(steps) == 0.
+	return steps, nil
+}
+
+// decodeEscapes decodes the supported backslash escapes in a send payload:
+// \r \n \t \\ and \xNN (two hex digits). Other escapes are an error so typos
+// surface instead of silently passing through.
+//
+//nolint:cyclop // a flat escape dispatcher; splitting it would not aid clarity
+func decodeEscapes(s string) ([]byte, error) {
+	const (
+		hexBase    = 16
+		hexBitSize = 8
+		hexDigits  = 2
+	)
+
+	out := make([]byte, 0, len(s))
+
+	for idx := 0; idx < len(s); idx++ {
+		if s[idx] != '\\' {
+			out = append(out, s[idx])
+
+			continue
+		}
+
+		idx++
+		if idx >= len(s) {
+			return nil, fmt.Errorf("trailing backslash")
+		}
+
+		switch s[idx] {
+		case 'r':
+			out = append(out, '\r')
+		case 'n':
+			out = append(out, '\n')
+		case 't':
+			out = append(out, '\t')
+		case '\\':
+			out = append(out, '\\')
+		case 'x':
+			if idx+hexDigits >= len(s) {
+				return nil, fmt.Errorf(`\x requires two hex digits`)
+			}
+
+			v, err := strconv.ParseUint(s[idx+1:idx+1+hexDigits], hexBase, hexBitSize)
+			if err != nil {
+				return nil, fmt.Errorf(`invalid \x escape %q: %w`, s[idx+1:idx+1+hexDigits], err)
+			}
+
+			out = append(out, byte(v))
+			idx += hexDigits
+		default:
+			return nil, fmt.Errorf("unknown escape %q", `\`+string(s[idx]))
+		}
+	}
+
+	return out, nil
+}

--- a/pkg/module/serial/step_test.go
+++ b/pkg/module/serial/step_test.go
@@ -1,0 +1,228 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package serial
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseArgsSequence(t *testing.T) {
+	cfg, err := parseArgs([]string{"-t", "30s", "--", "send", "foo", "expect", "bar", "send-raw", "x"})
+	if err != nil {
+		t.Fatalf("parseArgs: %v", err)
+	}
+
+	if cfg.timeout != 30*time.Second {
+		t.Errorf("timeout = %s, want 30s", cfg.timeout)
+	}
+
+	if len(cfg.steps) != 3 {
+		t.Fatalf("len(steps) = %d, want 3", len(cfg.steps))
+	}
+
+	if cfg.steps[0].kind != stepSend || string(cfg.steps[0].payload) != "foo\r" {
+		t.Errorf("step0 = %+v, want send %q", cfg.steps[0], "foo\\r")
+	}
+
+	if cfg.steps[1].kind != stepExpect || cfg.steps[1].expect == nil || !cfg.steps[1].expect.MatchString("xbarx") {
+		t.Errorf("step1 = %+v, want expect matching 'bar'", cfg.steps[1])
+	}
+
+	if cfg.steps[2].kind != stepSendRaw || string(cfg.steps[2].payload) != "x" {
+		t.Errorf("step2 = %+v, want send-raw %q (no EOL)", cfg.steps[2], "x")
+	}
+}
+
+func TestParseArgsEOL(t *testing.T) {
+	tests := []struct {
+		eol  string
+		want string
+	}{
+		{"cr", "foo\r"},
+		{"lf", "foo\n"},
+		{"crlf", "foo\r\n"},
+		{"none", "foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.eol, func(t *testing.T) {
+			cfg, err := parseArgs([]string{"-eol", tt.eol, "--", "send", "foo"})
+			if err != nil {
+				t.Fatalf("parseArgs: %v", err)
+			}
+
+			if got := string(cfg.steps[0].payload); got != tt.want {
+				t.Errorf("payload = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseArgsDefaultEOLIsCR(t *testing.T) {
+	cfg, err := parseArgs([]string{"--", "send", "foo"})
+	if err != nil {
+		t.Fatalf("parseArgs: %v", err)
+	}
+
+	if got := string(cfg.steps[0].payload); got != "foo\r" {
+		t.Errorf("default payload = %q, want %q (CR)", got, "foo\\r")
+	}
+}
+
+func TestParseArgsErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"expect missing pattern", []string{"--", "expect"}},
+		{"send missing data", []string{"--", "send"}},
+		{"unknown verb", []string{"--", "frobnicate", "x"}},
+		{"bad regex", []string{"--", "expect", "("}},
+		{"bad eol", []string{"-eol", "wat", "--", "send", "x"}},
+		{"bad escape", []string{"--", "send", `x\q`}},
+		{"trailing backslash", []string{"--", "send", `x\`}},
+		{"short hex escape", []string{"--", "send", `x\x4`}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseArgs(tt.args); err == nil {
+				t.Errorf("parseArgs(%q) = nil error, want error", tt.args)
+			}
+		})
+	}
+}
+
+func TestDecodeEscapes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []byte
+	}{
+		{"plain", `hello`, []byte("hello")},
+		{"named escapes", `a\r\n\tb`, []byte("a\r\n\tb")},
+		{"backslash", `a\\b`, []byte(`a\b`)},
+		{"hex", `\x41\x42`, []byte("AB")},
+		{"ctrl-c", `\x03`, []byte{0x03}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeEscapes(tt.in)
+			if err != nil {
+				t.Fatalf("decodeEscapes(%q): %v", tt.in, err)
+			}
+
+			if string(got) != string(tt.want) {
+				t.Errorf("decodeEscapes(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveEOL(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		want string
+	}{
+		{"cr", "\r"},
+		{"CR", "\r"},
+		{"lf", "\n"},
+		{"crlf", "\r\n"},
+		{"none", ""},
+	} {
+		got, err := resolveEOL(tt.name)
+		if err != nil {
+			t.Fatalf("resolveEOL(%q): %v", tt.name, err)
+		}
+
+		if string(got) != tt.want {
+			t.Errorf("resolveEOL(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+
+	if _, err := resolveEOL("nonsense"); err == nil {
+		t.Error("resolveEOL(nonsense) = nil error, want error")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		limit int
+		want  string
+	}{
+		{"shorter than limit", "login:", 60, "login:"},
+		{"exactly limit", "abcde", 5, "abcde"},
+		{"longer than limit", "abcdefgh", 5, "abcde..."},
+		{"multibyte not split", "héllo wörld", 5, "héllo..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := truncate(tt.in, tt.limit); got != tt.want {
+				t.Errorf("truncate(%q, %d) = %q, want %q", tt.in, tt.limit, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStepLabel(t *testing.T) {
+	long := strings.Repeat("x", maxLabelLen+10)
+
+	got := step{src: long}.label()
+	if want := maxLabelLen + len("..."); len([]rune(got)) != want {
+		t.Errorf("label rune length = %d, want %d (maxLabelLen + ellipsis)", len([]rune(got)), want)
+	}
+
+	if short := (step{src: "ok"}).label(); short != "ok" {
+		t.Errorf("short label = %q, want %q (unchanged)", short, "ok")
+	}
+}
+
+func TestParseArgsMonitor(t *testing.T) {
+	// No step args selects monitor mode: zero steps, no error.
+	cfg, err := parseArgs(nil)
+	if err != nil {
+		t.Fatalf("parseArgs(nil): %v", err)
+	}
+
+	if len(cfg.steps) != 0 {
+		t.Errorf("steps = %d, want 0 (monitor mode)", len(cfg.steps))
+	}
+
+	// Flags without steps are still monitor mode, with the flag applied.
+	cfg, err = parseArgs([]string{"-t", "5s"})
+	if err != nil {
+		t.Fatalf("parseArgs(-t 5s): %v", err)
+	}
+
+	if len(cfg.steps) != 0 || cfg.timeout != 5*time.Second {
+		t.Errorf("got steps=%d timeout=%s, want 0 steps and 5s", len(cfg.steps), cfg.timeout)
+	}
+}
+
+func TestParseArgsKeepEscapes(t *testing.T) {
+	cfg, err := parseArgs([]string{"-keep-escapes", "--", "expect", "x"})
+	if err != nil {
+		t.Fatalf("parseArgs(-keep-escapes): %v", err)
+	}
+
+	if !cfg.keepEscapes {
+		t.Error("keepEscapes = false, want true")
+	}
+
+	cfg, err = parseArgs([]string{"--", "expect", "x"})
+	if err != nil {
+		t.Fatalf("parseArgs: %v", err)
+	}
+
+	if cfg.keepEscapes {
+		t.Error("keepEscapes = true by default, want false")
+	}
+}


### PR DESCRIPTION
Rework the serial module from a single read-only expect into a
non-interactive automation engine driven entirely by up-front arguments,
suitable for scripts and machines.

Modes:
  - Monitor (no steps): stream the serial output to the client until the
    session is cancelled or -t elapses (a success).
  - Sequence (one or more steps): run expect / send / send-raw steps in
    order; the run fails on the first expect that times out.

Grammar: [-t <dur>] [-eol cr|lf|crlf|none] [-keep-escapes] [--] <step>... where
a step is expect <regex> / send <data> / send-raw <data>. send payloads support
the escapes \r \n \t \\ and \xNN (e.g. \x03 for Ctrl-C). Per-step progress is
reported to the client as "--- [n/total] matched/sent ... ---" markers. If the
last step is a send, output is shown briefly afterwards so the DUT's reply is
visible.

A 'delay' module option (with: delay, default 50ms; "0s" disables) paces input
by pausing before each send, for consoles that present a prompt before the tty
is ready to read.

By default terminal escape sequences (cursor moves, colour, queries) are
stripped from the output before it is shown or matched, so they don't break
expect patterns; pass -keep-escapes to forward the raw stream (e.g. binary
data).

Internals: a port interface plus a per-run engine with a 64 KiB rolling
match buffer (matches across reads, never newline-reset) and a tee that
forwards serial output to the client. Structured so an interactive
session.Console mode can be added later.

Also migrate the serial backend from the unmaintained tarm/serial to
go.bug.st/serial, and update the module README and example config.

BREAKING CHANGE: The serial module's invocation changed. It no longer accepts
a single optional expect regex; callers must pass an explicit step sequence.
For example, `serial "(?i)hello"` becomes `serial -- expect "(?i)hello"`.
Existing configs/scripts using the old form must be updated.