### PR TITLE
Ignore top-level taskfile.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/
 .task/
+/taskfile.yml
 /dutctl
 /cmds/dutctl/dutctl
 /dutagent


### PR DESCRIPTION
Local top-level task files should stay ignored for local developer setups.
(As of now)