### PR TITLE
Stop Dependabot applying ecosystem labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: '/'
+    labels: ["dependencies"]
     schedule:
       interval: 'daily'
     commit-message:
@@ -10,6 +11,7 @@ updates:
       
   - package-ecosystem: 'github-actions'
     directory: '/'
+    labels: ["dependencies"]
     schedule:
       interval: 'daily'
     commit-message:


### PR DESCRIPTION
Pin labels: ["dependencies"] on both update entries so Dependabot no longer adds the redundant `go` and `github_actions` ecosystem labels. In a pure-Go repo they carry no signal, and freeing the names lets us retire those labels from the issue-label taxonomy.