### PR TITLE
Add Gude PDU support via pluggable vendor backends

### DIFF
--- a/pkg/module/pdu/README.md
+++ b/pkg/module/pdu/README.md
@@ -2,7 +2,7 @@
 
 The _PDU_ module provides basic power control of a Power Distribution Unit (PDU) via HTTP requests. It supports turning a power outlet on, off, toggling its state, and querying the current status.
 
-**Note**: This module currently supports only Intellinet ATM PDUs.
+**Note**: This module supports Intellinet-style PDUs (e.g. Intellinet 163682, LogiLink PDU8P01) and Gude PDUs. Select the device with the `vendor` option.
 
 This module is intended to be used as part of `dutagent`, allowing automated power control of a DUT (Device Under Test) through a network-accessible PDU.
 
@@ -23,13 +23,14 @@ pdu [on|off|toggle|status]
 
 If no command is provided, the module prints a usage message and exits.
 
-See [pdu-example-cfg.yml](./pdu-example-cfg.yml) for examples. 
+See [pdu-example-cfg.yml](./pdu-example-cfg.yml) for examples.
 
 ## Configuration Options
 
-| Option     | Type   | Description                                    |
-| ---------- | ------ | ---------------------------------------------- |
-| `host`     | string | Base URL of the PDU (e.g. `10.0.0.5`)          |
-| `user`     | string | (Optional) Username for HTTP Basic Auth        |
-| `password` | string | (Optional) Password for HTTP Basic Auth        |
-| `outlet`   | int    | Outlet number to control (0-15, defaults to 0) |
+| Option     | Type   | Description                                                    |
+| ---------- | ------ | ------------------------------------------------------------- |
+| `vendor`   | string | PDU HTTP API: `intellinet` (default) or `gude`                       |
+| `host`     | string | Base URL of the PDU, including scheme (e.g. `http://10.0.0.5`)        |
+| `user`     | string | (Optional) Username for HTTP Basic Auth; set together with `password` |
+| `password` | string | (Optional) Password for HTTP Basic Auth; set together with `user`    |
+| `outlet`   | int    | Outlet to control (0-based, defaults to 0); upper bound is device-specific |

--- a/pkg/module/pdu/gude.go
+++ b/pkg/module/pdu/gude.go
@@ -1,0 +1,171 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pdu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+)
+
+// gudeCmdSwitch is the Gude "cmd" query value that switches an outlet on or off.
+const gudeCmdSwitch = "1"
+
+// gude drives Gude PDUs via their statusjsn.js and ov.html HTTP+JSON API.
+type gude struct {
+	req  *requester
+	base *url.URL
+}
+
+// setPower implements the backend interface for Gude PDUs. Gude has no native
+// toggle, so toggle is emulated by reading the current state and switching to
+// its opposite via the ov.html endpoint.
+func (g gude) setPower(ctx context.Context, outlet int, act action) (state, error) {
+	var newState gudeState
+
+	switch act {
+	case turnOn:
+		newState = gudeOn
+	case turnOff:
+		newState = gudeOff
+	case toggle:
+		current, err := g.readState(ctx, outlet)
+		if err != nil {
+			return off, fmt.Errorf("could not read outlet %d state to toggle it: %w", outlet, err)
+		}
+
+		newState = current.toggled()
+	default:
+		return off, fmt.Errorf("invalid PDU operation: %s", act)
+	}
+
+	endpoint := g.base.JoinPath("ov.html")
+	// Outlet is a 0-based index (0 = first outlet), matching Gude's status array.
+	// Gude's switch API numbers ports from 1, so "p" is Outlet+1.
+	endpoint.RawQuery = url.Values{
+		"cmd": {gudeCmdSwitch},
+		"p":   {strconv.Itoa(outlet + 1)},
+		"s":   {newState.switchValue()},
+	}.Encode()
+
+	resp, err := g.req.get(ctx, endpoint.String())
+	if err != nil {
+		return off, err
+	}
+
+	resp.Body.Close()
+
+	// newState is the value just written — for a toggle it was derived from a
+	// fresh read above — so it is the resulting state and needs no post-write
+	// read-back (unlike Intellinet's fire-and-forget toggle).
+	return newState.common(), nil
+}
+
+// outletState implements the backend interface for Gude PDUs, reading the
+// outlet state from the statusjsn.js endpoint.
+func (g gude) outletState(ctx context.Context, outlet int) (state, error) {
+	current, err := g.readState(ctx, outlet)
+	if err != nil {
+		return off, err
+	}
+
+	return current.common(), nil
+}
+
+// readState fetches the outlet's current state from the status API in Gude's
+// own encoding, which setPower needs to compute a toggle.
+func (g gude) readState(ctx context.Context, outlet int) (gudeState, error) {
+	endpoint := g.base.JoinPath("statusjsn.js")
+	endpoint.RawQuery = "components=1"
+
+	resp, err := g.req.get(ctx, endpoint.String())
+	if err != nil {
+		return gudeOff, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return gudeOff, err
+	}
+
+	return g.parseOutlet(body, outlet)
+}
+
+// parseOutlet extracts the outlet's state from a statusjsn.js JSON response body.
+func (g gude) parseOutlet(body []byte, outlet int) (gudeState, error) {
+	var response gudeStatusResponse
+
+	err := json.Unmarshal(body, &response)
+	if err != nil {
+		return gudeOff, fmt.Errorf("failed to parse Gude status response: %w", err)
+	}
+
+	if len(response.Outputs) == 0 {
+		return gudeOff, fmt.Errorf("no outputs found in PDU status response")
+	}
+
+	if outlet < 0 || outlet >= len(response.Outputs) {
+		return gudeOff, fmt.Errorf("outlet %d not found in PDU status (only %d outlets available)", outlet, len(response.Outputs))
+	}
+
+	return gudeStateFromInt(response.Outputs[outlet].State)
+}
+
+// gudeStatusResponse is the subset of the Gude status endpoint's JSON response
+// that this module consumes.
+type gudeStatusResponse struct {
+	Outputs []struct {
+		State int `json:"state"` // 0 = off, 1 = on.
+	} `json:"outputs"`
+}
+
+// gudeState is Gude's internal encoding of an outlet's power state. The device
+// uses this state in two forms across its two endpoints: the integer "state"
+// field of the statusjsn.js response (read via gudeStateFromInt) and the "s"
+// query parameter of the ov.html switch request (written via switchValue).
+// Both use 0 = off and 1 = on, so gudeState's integer value maps to the wire directly.
+type gudeState int
+
+const (
+	gudeOff gudeState = iota
+	gudeOn
+)
+
+// switchValue returns the value Gude's switch request expects in its "s"
+// parameter ("1" for on, "0" for off).
+func (g gudeState) switchValue() string {
+	return strconv.Itoa(int(g))
+}
+
+// toggled returns the opposite state.
+func (g gudeState) toggled() gudeState {
+	if g == gudeOn {
+		return gudeOff
+	}
+
+	return gudeOn
+}
+
+// common converts Gude's encoding to the vendor-neutral state.
+func (g gudeState) common() state {
+	if g == gudeOn {
+		return on
+	}
+
+	return off
+}
+
+// gudeStateFromInt maps Gude's integer "state" field (0 = off, 1 = on) to a gudeState.
+func gudeStateFromInt(value int) (gudeState, error) {
+	if value != int(gudeOff) && value != int(gudeOn) {
+		return gudeOff, fmt.Errorf("invalid Gude outlet state: %d", value)
+	}
+
+	return gudeState(value), nil
+}

--- a/pkg/module/pdu/gude_test.go
+++ b/pkg/module/pdu/gude_test.go
@@ -1,0 +1,333 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pdu
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// newTestGude builds a gude backend pointed at srv, sharing its client so the
+// tests exercise the real request-building path.
+func newTestGude(t *testing.T, srv *httptest.Server) gude {
+	t.Helper()
+
+	base, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", srv.URL, err)
+	}
+
+	return gude{req: &requester{client: srv.Client()}, base: base}
+}
+
+func TestGudeStateSwitchValue(t *testing.T) {
+	if got := gudeOff.switchValue(); got != "0" {
+		t.Errorf("gudeOff.switchValue() = %q, want %q", got, "0")
+	}
+
+	if got := gudeOn.switchValue(); got != "1" {
+		t.Errorf("gudeOn.switchValue() = %q, want %q", got, "1")
+	}
+}
+
+func TestGudeStateToggled(t *testing.T) {
+	if got := gudeOn.toggled(); got != gudeOff {
+		t.Errorf("gudeOn.toggled() = %v, want gudeOff", got)
+	}
+
+	if got := gudeOff.toggled(); got != gudeOn {
+		t.Errorf("gudeOff.toggled() = %v, want gudeOn", got)
+	}
+}
+
+func TestGudeStateCommon(t *testing.T) {
+	if got := gudeOn.common(); got != on {
+		t.Errorf("gudeOn.common() = %v, want on", got)
+	}
+
+	if got := gudeOff.common(); got != off {
+		t.Errorf("gudeOff.common() = %v, want off", got)
+	}
+}
+
+func TestGudeStateFromInt(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   int
+		want    gudeState
+		wantErr bool
+	}{
+		{name: "0 is off", input: 0, want: gudeOff},
+		{name: "1 is on", input: 1, want: gudeOn},
+		{name: "2 is invalid", input: 2, wantErr: true},
+		{name: "negative is invalid", input: -1, wantErr: true},
+		{name: "large is invalid", input: 999, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := gudeStateFromInt(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("gudeStateFromInt() expected error but got none")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("gudeStateFromInt() unexpected error: %v", err)
+
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("gudeStateFromInt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGudeParseOutlet(t *testing.T) {
+	tests := []struct {
+		name     string
+		outlet   int
+		jsonBody string
+		want     gudeState
+		wantErr  bool
+	}{
+		{
+			name:   "outlet 0 off",
+			outlet: 0,
+			jsonBody: `{
+				"outputs": [
+					{"name": "Power Port", "state": 0},
+					{"name": "Power Port", "state": 1}
+				]
+			}`,
+			want: gudeOff,
+		},
+		{
+			name:   "outlet 1 on",
+			outlet: 1,
+			jsonBody: `{
+				"outputs": [
+					{"name": "Power Port", "state": 0},
+					{"name": "Power Port", "state": 1}
+				]
+			}`,
+			want: gudeOn,
+		},
+		{
+			name:   "real PDU response - 4 outlets",
+			outlet: 2,
+			jsonBody: `{
+				"outputs": [
+					{"name": "Power Port", "state": 0, "sw_cnt": 8, "type": 1, "batch": [0,0], "wdog": [0,3,null,32]},
+					{"name": "Power Port", "state": 0},
+					{"name": "Power Port", "state": 1},
+					{"name": "Power Port", "state": 0}
+				]
+			}`,
+			want: gudeOn,
+		},
+		{
+			name:   "outlet not found - out of range",
+			outlet: 5,
+			jsonBody: `{
+				"outputs": [
+					{"name": "Power Port", "state": 0},
+					{"name": "Power Port", "state": 1}
+				]
+			}`,
+			wantErr: true,
+		},
+		{
+			name:     "malformed JSON - missing closing brace",
+			outlet:   0,
+			jsonBody: `{"outputs": [{"name": "Power Port", "state": 0}`,
+			wantErr:  true,
+		},
+		{
+			name:     "empty outputs array",
+			outlet:   0,
+			jsonBody: `{"outputs": []}`,
+			wantErr:  true,
+		},
+		{
+			name:     "empty JSON",
+			outlet:   0,
+			jsonBody: ``,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid JSON - not an object",
+			outlet:   0,
+			jsonBody: `null`,
+			wantErr:  true,
+		},
+		{
+			name:   "missing outputs field",
+			outlet: 0,
+			jsonBody: `{
+				"other_field": "value"
+			}`,
+			wantErr: true,
+		},
+		{
+			name:   "unexpected state value returns error",
+			outlet: 0,
+			jsonBody: `{
+				"outputs": [
+					{"name": "Power Port", "state": 7}
+				]
+			}`,
+			wantErr: true,
+		},
+		{
+			name:   "outlet at exact boundary - last outlet",
+			outlet: 3,
+			jsonBody: `{
+				"outputs": [
+					{"name": "Port 1", "state": 0},
+					{"name": "Port 2", "state": 1},
+					{"name": "Port 3", "state": 0},
+					{"name": "Port 4", "state": 1}
+				]
+			}`,
+			want: gudeOn,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := gude{}.parseOutlet([]byte(tt.jsonBody), tt.outlet)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseOutlet() expected error but got none")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("parseOutlet() unexpected error: %v", err)
+
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("parseOutlet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGudeOutletState pins Gude's status contract: the state is read from
+// GET /statusjsn.js?components=1 and taken from the outlet's "state" field.
+func TestGudeOutletState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/statusjsn.js" {
+			t.Errorf("request path = %q, want /statusjsn.js", r.URL.Path)
+		}
+
+		if got := r.URL.Query().Get("components"); got != "1" {
+			t.Errorf("components query = %q, want %q", got, "1")
+		}
+
+		fmt.Fprint(w, `{"outputs":[{"state":0},{"state":1}]}`)
+	}))
+	defer srv.Close()
+
+	got, err := newTestGude(t, srv).outletState(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("outletState() unexpected error: %v", err)
+	}
+
+	if got != on {
+		t.Errorf("outletState() = %v, want on", got)
+	}
+}
+
+// TestGudeSetPowerRequests pins Gude's switch contract on GET /ov.html: cmd=1,
+// the 1-based port index p=outlet+1, and s=1/0 for on/off. Gude has no native
+// toggle, so a toggle first reads /statusjsn.js and then writes the opposite s.
+func TestGudeSetPowerRequests(t *testing.T) {
+	const outlet = 2 // Gude's switch API is 1-based, so requests must carry p=3.
+
+	tests := []struct {
+		name      string
+		act       action
+		current   gudeState // state /statusjsn.js reports; only a toggle reads it back
+		wantS     string    // expected "s" switch parameter
+		wantState state     // expected resulting state
+	}{
+		{name: "on", act: turnOn, wantS: "1", wantState: on},
+		{name: "off", act: turnOff, wantS: "0", wantState: off},
+		{name: "toggle from on switches off", act: toggle, current: gudeOn, wantS: "0", wantState: off},
+		{name: "toggle from off switches on", act: toggle, current: gudeOff, wantS: "1", wantState: on},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				switchQuery url.Values
+				statusHits  int
+			)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/statusjsn.js":
+					statusHits++
+
+					fmt.Fprintf(w, `{"outputs":[{"state":0},{"state":0},{"state":%d}]}`, tt.current)
+				case "/ov.html":
+					switchQuery = r.URL.Query()
+
+					w.WriteHeader(http.StatusOK)
+				default:
+					t.Errorf("unexpected request path %q", r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+
+			got, err := newTestGude(t, srv).setPower(context.Background(), outlet, tt.act)
+			if err != nil {
+				t.Fatalf("setPower() unexpected error: %v", err)
+			}
+
+			if got != tt.wantState {
+				t.Errorf("setPower() = %v, want %v", got, tt.wantState)
+			}
+
+			if switchQuery.Get("cmd") != gudeCmdSwitch {
+				t.Errorf("ov.html cmd = %q, want %q", switchQuery.Get("cmd"), gudeCmdSwitch)
+			}
+
+			if switchQuery.Get("p") != "3" {
+				t.Errorf("ov.html p = %q, want %q (1-based index of outlet %d)", switchQuery.Get("p"), "3", outlet)
+			}
+
+			if switchQuery.Get("s") != tt.wantS {
+				t.Errorf("ov.html s = %q, want %q", switchQuery.Get("s"), tt.wantS)
+			}
+
+			wantStatusHits := 0
+			if tt.act == toggle {
+				wantStatusHits = 1 // a toggle must read the current state first
+			}
+
+			if statusHits != wantStatusHits {
+				t.Errorf("statusjsn.js hits = %d, want %d", statusHits, wantStatusHits)
+			}
+		})
+	}
+}

--- a/pkg/module/pdu/intellinet.go
+++ b/pkg/module/pdu/intellinet.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pdu
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+)
+
+// intellinet drives Intellinet-style PDUs (also the LogiLink PDU8P01 and
+// compatibles) via their control_outlet.htm and status.xml HTTP endpoints.
+type intellinet struct {
+	req  *requester
+	base *url.URL
+}
+
+// setPower implements the backend interface for Intellinet-style PDUs, using the
+// native on/off/toggle "op" parameter of the control_outlet.htm endpoint.
+func (i intellinet) setPower(ctx context.Context, outlet int, act action) (state, error) {
+	op, ok := intellinetOpFor(act)
+	if !ok {
+		return off, fmt.Errorf("invalid PDU operation: %s", act)
+	}
+
+	// control_outlet.htm selects the target outlet with "outlet<N>=1" and the
+	// action with "op".
+	outletParam := fmt.Sprintf("outlet%d", outlet)
+
+	endpoint := i.base.JoinPath("control_outlet.htm")
+	endpoint.RawQuery = url.Values{
+		outletParam: {"1"},
+		"op":        {string(op)},
+	}.Encode()
+
+	resp, err := i.req.get(ctx, endpoint.String())
+	if err != nil {
+		return off, err
+	}
+
+	resp.Body.Close()
+
+	// The control endpoint does not echo the resulting state: for on/off it is
+	// the action's state, but a toggle must be read back.
+	if act == toggle {
+		result, err := i.outletState(ctx, outlet)
+		if err != nil {
+			return off, fmt.Errorf("toggled outlet %d but could not read back the resulting state: %w", outlet, err)
+		}
+
+		return result, nil
+	}
+
+	if act == turnOn {
+		return on, nil
+	}
+
+	return off, nil
+}
+
+// outletState implements the backend interface for Intellinet-style PDUs,
+// parsing the outlet state from the status.xml endpoint.
+func (i intellinet) outletState(ctx context.Context, outlet int) (state, error) {
+	endpoint := i.base.JoinPath("status.xml")
+
+	resp, err := i.req.get(ctx, endpoint.String())
+	if err != nil {
+		return off, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return off, err
+	}
+
+	return i.parseOutlet(body, outlet)
+}
+
+// parseOutlet extracts the outlet's state from a status.xml response body. The
+// Intellinet status reports the state as the same "on"/"off" words the common
+// state uses, so no vendor-specific state type is needed.
+func (i intellinet) parseOutlet(body []byte, outlet int) (state, error) {
+	bodyStr := string(body)
+
+	outletTag := fmt.Sprintf("<outletStat%d>", outlet)
+	outletEndTag := fmt.Sprintf("</outletStat%d>", outlet)
+
+	startIdx := strings.Index(bodyStr, outletTag)
+	if startIdx == -1 {
+		return off, fmt.Errorf("outlet %d not found in PDU status", outlet)
+	}
+
+	startIdx += len(outletTag)
+
+	endIdx := strings.Index(bodyStr[startIdx:], outletEndTag)
+	if endIdx == -1 {
+		return off, fmt.Errorf("malformed XML for outlet %d", outlet)
+	}
+
+	value := strings.TrimSpace(bodyStr[startIdx : startIdx+endIdx])
+
+	result, ok := parseState(value)
+	if !ok {
+		return off, fmt.Errorf("unexpected outlet state %q for outlet %d", value, outlet)
+	}
+
+	return result, nil
+}
+
+// intellinetOp is the value the Intellinet control_outlet.htm endpoint expects in
+// its "op" query parameter. The encoding is action-based rather than a boolean
+// state, and notably inverts what one might expect: 0 = switch on, 1 = switch
+// off, 2 = toggle.
+type intellinetOp string
+
+const (
+	opOn     intellinetOp = "0"
+	opOff    intellinetOp = "1"
+	opToggle intellinetOp = "2"
+)
+
+// intellinetOpFor maps a power action to its Intellinet op value; ok is false for an
+// unknown action.
+func intellinetOpFor(act action) (intellinetOp, bool) {
+	switch act {
+	case turnOn:
+		return opOn, true
+	case turnOff:
+		return opOff, true
+	case toggle:
+		return opToggle, true
+	default:
+		return "", false
+	}
+}

--- a/pkg/module/pdu/intellinet_test.go
+++ b/pkg/module/pdu/intellinet_test.go
@@ -1,0 +1,269 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pdu
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// newTestIntellinet builds an intellinet backend pointed at srv, sharing its
+// client so the tests exercise the real request-building path.
+func newTestIntellinet(t *testing.T, srv *httptest.Server) intellinet {
+	t.Helper()
+
+	base, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", srv.URL, err)
+	}
+
+	return intellinet{req: &requester{client: srv.Client()}, base: base}
+}
+
+func TestIntellinetParseOutlet(t *testing.T) {
+	tests := []struct {
+		name    string
+		outlet  int
+		xmlBody string
+		want    state
+		wantErr bool
+	}{
+		{
+			name:   "outlet 0 on",
+			outlet: 0,
+			xmlBody: `<response>
+<outletStat0>on</outletStat0>
+<outletStat1>off</outletStat1>
+</response>`,
+			want: on,
+		},
+		{
+			name:   "outlet 1 off",
+			outlet: 1,
+			xmlBody: `<response>
+<outletStat0>on</outletStat0>
+<outletStat1>off</outletStat1>
+</response>`,
+			want: off,
+		},
+		{
+			name:   "outlet 6 on with whitespace",
+			outlet: 6,
+			xmlBody: `<response>
+<outletStat6>  on  </outletStat6>
+</response>`,
+			want: on,
+		},
+		{
+			name:   "outlet not found",
+			outlet: 5,
+			xmlBody: `<response>
+<outletStat0>on</outletStat0>
+<outletStat1>off</outletStat1>
+</response>`,
+			wantErr: true,
+		},
+		{
+			name:   "malformed XML - missing end tag",
+			outlet: 0,
+			xmlBody: `<response>
+<outletStat0>on
+</response>`,
+			wantErr: true,
+		},
+		{
+			name:   "unexpected outlet state",
+			outlet: 0,
+			xmlBody: `<response>
+<outletStat0>unknown</outletStat0>
+</response>`,
+			wantErr: true,
+		},
+		{
+			name:   "real PDU response example",
+			outlet: 6,
+			xmlBody: `<response>
+<cur0>0.2</cur0>
+<stat0>normal</stat0>
+<curBan>0.2</curBan>
+<tempBan>30</tempBan>
+<humBan>31</humBan>
+<statBan>normal</statBan>
+<outletStat0>on</outletStat0>
+<outletStat1>on</outletStat1>
+<outletStat2>on</outletStat2>
+<outletStat3>on</outletStat3>
+<outletStat4>on</outletStat4>
+<outletStat5>on</outletStat5>
+<outletStat6>on</outletStat6>
+<outletStat7>off</outletStat7>
+<userVerifyRes>0</userVerifyRes>
+</response>`,
+			want: on,
+		},
+		{
+			name:    "empty XML",
+			outlet:  0,
+			xmlBody: "",
+			wantErr: true,
+		},
+		{
+			name:   "outlet number out of range",
+			outlet: 99,
+			xmlBody: `<response>
+<outletStat0>on</outletStat0>
+</response>`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := intellinet{}.parseOutlet([]byte(tt.xmlBody), tt.outlet)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseOutlet() expected error but got none")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("parseOutlet() unexpected error: %v", err)
+
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("parseOutlet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIntellinetOpFor(t *testing.T) {
+	tests := []struct {
+		name string
+		a    action
+		want intellinetOp
+		ok   bool
+	}{
+		{name: "turn on", a: turnOn, want: opOn, ok: true},
+		{name: "turn off", a: turnOff, want: opOff, ok: true},
+		{name: "toggle", a: toggle, want: opToggle, ok: true},
+		{name: "unknown action", a: action(99), want: "", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := intellinetOpFor(tt.a)
+			if ok != tt.ok {
+				t.Fatalf("intellinetOpFor(%v) ok = %v, want %v", tt.a, ok, tt.ok)
+			}
+
+			if got != tt.want {
+				t.Errorf("intellinetOpFor(%v) = %q, want %q", tt.a, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIntellinetOutletState pins Intellinet's status contract: the state is
+// read from GET /status.xml and parsed from the outlet's <outletStatN> element.
+func TestIntellinetOutletState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/status.xml" {
+			t.Errorf("request path = %q, want /status.xml", r.URL.Path)
+		}
+
+		fmt.Fprint(w, `<response><outletStat0>on</outletStat0><outletStat1>off</outletStat1></response>`)
+	}))
+	defer srv.Close()
+
+	got, err := newTestIntellinet(t, srv).outletState(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("outletState() unexpected error: %v", err)
+	}
+
+	if got != off {
+		t.Errorf("outletState() = %v, want off", got)
+	}
+}
+
+// TestIntellinetSetPowerRequests pins Intellinet's switch contract on
+// GET /control_outlet.htm: the outlet is selected with outlet<N>=1 and the
+// action with the inverted op code (0=on, 1=off, 2=toggle). The endpoint does
+// not echo the result, so a toggle is read back from /status.xml.
+func TestIntellinetSetPowerRequests(t *testing.T) {
+	const outlet = 6 // control_outlet.htm selects the outlet with "outlet6=1".
+
+	tests := []struct {
+		name      string
+		act       action
+		wantOp    string
+		readBack  state // state /status.xml reports after a toggle read-back
+		wantState state
+	}{
+		{name: "on", act: turnOn, wantOp: "0", wantState: on},
+		{name: "off", act: turnOff, wantOp: "1", wantState: off},
+		{name: "toggle reads the resulting state back", act: toggle, wantOp: "2", readBack: on, wantState: on},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				controlQuery url.Values
+				statusHits   int
+			)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/control_outlet.htm":
+					controlQuery = r.URL.Query()
+
+					w.WriteHeader(http.StatusOK)
+				case "/status.xml":
+					statusHits++
+
+					fmt.Fprintf(w, `<response><outletStat6>%s</outletStat6></response>`, tt.readBack)
+				default:
+					t.Errorf("unexpected request path %q", r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+
+			got, err := newTestIntellinet(t, srv).setPower(context.Background(), outlet, tt.act)
+			if err != nil {
+				t.Fatalf("setPower() unexpected error: %v", err)
+			}
+
+			if got != tt.wantState {
+				t.Errorf("setPower() = %v, want %v", got, tt.wantState)
+			}
+
+			if controlQuery.Get("outlet6") != "1" {
+				t.Errorf("control_outlet.htm outlet6 = %q, want %q", controlQuery.Get("outlet6"), "1")
+			}
+
+			if controlQuery.Get("op") != tt.wantOp {
+				t.Errorf("control_outlet.htm op = %q, want %q", controlQuery.Get("op"), tt.wantOp)
+			}
+
+			wantStatusHits := 0
+			if tt.act == toggle {
+				wantStatusHits = 1 // only a toggle reads the state back
+			}
+
+			if statusHits != wantStatusHits {
+				t.Errorf("status.xml hits = %d, want %d", statusHits, wantStatusHits)
+			}
+		})
+	}
+}

--- a/pkg/module/pdu/pdu-example-cfg.yml
+++ b/pkg/module/pdu/pdu-example-cfg.yml
@@ -1,15 +1,30 @@
 version: 1.0.0-alpha.1 # x-release-please-version
 devices:
   fancy-server:
-    desc: "A server with power control via PDU"
+    desc: "A server with power control via an Intellinet PDU"
     cmds:
-      power-on:
-        desc: "Turn the power ON via PDU"
+      power:
+        desc: "Control the power (on|off|toggle|status) via PDU"
         uses:
           - module: pdu
             passthrough: true
             with:
+              vendor: intellinet
               host: http://192.168.1.100
               user: admin
               password: admin
               outlet: 6
+  lab-server:
+    desc: "A server with power control via a Gude PDU"
+    cmds:
+      power:
+        desc: "Control the power (on|off|toggle|status) via PDU"
+        uses:
+          - module: pdu
+            passthrough: true
+            with:
+              vendor: gude
+              host: http://192.168.1.200
+              user: admin
+              password: admin
+              outlet: 1

--- a/pkg/module/pdu/pdu.go
+++ b/pkg/module/pdu/pdu.go
@@ -27,66 +27,164 @@ func init() {
 	})
 }
 
-// PDU is a module that provides basic power management functions for a PDU (Power Distribution Unit).
-// NOTE: This implementation currently supports only Intellinet ATM PDUs.
+// Supported PDU vendors, selected via the "vendor" configuration option. A
+// value names the device's HTTP API family rather than a single product:
+// "intellinet" also covers compatible units such as the LogiLink PDU8P01.
+const (
+	vendorIntellinet = "intellinet"
+	vendorGude       = "gude"
+)
+
+const defaultTimeout = 10 * time.Second // Default timeout for HTTP requests.
+
+// status is the query command that reports the current power state. Unlike the
+// power actions it does not change state, so it is dispatched on its own.
+const status = "status"
+
+// state is an outlet's power state. It is the common, vendor-neutral type that
+// crosses the backend interface; each backend converts it to and from its own
+// wire encoding.
+type state int
+
+const (
+	off state = iota
+	on
+)
+
+func (s state) String() string {
+	switch s {
+	case on:
+		return "on"
+	case off:
+		return "off"
+	default:
+		return ""
+	}
+}
+
+// parseState converts a device-reported power word ("on"/"off") to a state.
+func parseState(word string) (state, bool) {
+	switch word {
+	case on.String():
+		return on, true
+	case off.String():
+		return off, true
+	default:
+		return off, false
+	}
+}
+
+// action is a power command requested by the user. Its verb-like values
+// distinguish it from state: an outlet is never "in the toggle state".
+type action int
+
+const (
+	turnOn action = iota
+	turnOff
+	toggle
+)
+
+func (a action) String() string {
+	switch a {
+	case turnOn:
+		return "on"
+	case turnOff:
+		return "off"
+	case toggle:
+		return "toggle"
+	default:
+		return ""
+	}
+}
+
+// parseAction converts a user command word to a power action.
+func parseAction(word string) (action, bool) {
+	switch word {
+	case turnOn.String():
+		return turnOn, true
+	case turnOff.String():
+		return turnOff, true
+	case toggle.String():
+		return toggle, true
+	default:
+		return turnOn, false
+	}
+}
+
+// commandList returns the supported commands as a comma-separated string,
+// derived from the action and status commands so usage messages cannot drift.
+func commandList() string {
+	return strings.Join([]string{turnOn.String(), turnOff.String(), toggle.String(), status}, ", ")
+}
+
+// PDU is a module that provides basic power management functions for a PDU
+// (Power Distribution Unit). It supports Intellinet-style PDUs (e.g. Intellinet
+// 163682, LogiLink PDU8P01) and Gude PDUs; the concrete device is selected via
+// the Vendor option.
 type PDU struct {
+	Vendor   string `yaml:"vendor"` // Vendor selects the PDU HTTP API: "intellinet" (default) or "gude".
 	Host     string // Host is the base address of the PDU.
-	User     string // User is used for authentication, if supported by the PDU.
-	Password string // Password is used for authentication, if supported by the PDU.
+	User     string // User for HTTP Basic Auth; set together with Password, or leave both empty for no auth.
+	Password string // Password for HTTP Basic Auth; set together with User, or leave both empty for no auth.
 	Outlet   int    // Outlet is the outlet to control, if the PDU supports multiple outlets. Defaults to 0 (first outlet).
 
-	client     *http.Client // internal HTTP client for requests to the PDU
-	controlURL *url.URL     // controlURL is the URL for controlling the PDU outlet
-	statusURL  *url.URL     // statusURL is the URL for getting the PDU status
+	backend backend // vendor-specific API, selected in Init.
 }
 
 func (p *PDU) Help() string {
 	help := strings.Builder{}
 
-	help.WriteString("PDU Power Management Module\n")
+	help.WriteString("PDU module: control of a Power Distribution Unit (PDU) via HTTP.\n")
 	help.WriteString("\nUsage:\n")
-	help.WriteString("  pdu-power [on|off|toggle|status]\n\n")
+	help.WriteString("  pdu [on|off|toggle|status]\n\n")
 	help.WriteString("Commands:\n")
 	help.WriteString("  on      - Power on the outlet\n")
 	help.WriteString("  off     - Power off the outlet\n")
 	help.WriteString("  toggle  - Toggle the outlet power\n")
-	help.WriteString("  status  - Get current power state\n")
+	help.WriteString("  status  - Report the current power state\n")
 	help.WriteString("\n")
-	help.WriteString("This module provides basic power control functions via HTTP to a PDU.\n")
-	help.WriteString("The configured PDU has IP: " + p.Host + "\n")
-	help.WriteString(fmt.Sprintf("The configured outlet is: %d\n", p.Outlet))
+	fmt.Fprintf(&help, "Controls outlet %d of the PDU at %s via the %s API.\n", p.Outlet, p.Host, p.vendorLabel())
 
 	return help.String()
 }
 
-const (
-	defaultTimeout = 10 * time.Second // Default timeout for HTTP requests
-	on             = "on"
-	off            = "off"
-	toggle         = "toggle"
-	status         = "status"
-)
+// vendorLabel returns the configured vendor for display, flagging when the
+// default (see newBackend) applies because no vendor was set.
+func (p *PDU) vendorLabel() string {
+	if p.Vendor == "" {
+		return vendorIntellinet + " (default)"
+	}
+
+	return p.Vendor
+}
 
 func (p *PDU) Init(_ context.Context) error {
+	if p.Host == "" {
+		return fmt.Errorf("PDU host address not configured")
+	}
+
 	if p.Outlet < 0 {
 		return fmt.Errorf("invalid outlet number %d: outlet must be 0 or greater", p.Outlet)
 	}
 
-	p.client = &http.Client{Timeout: defaultTimeout}
+	// Basic Auth needs both parts; only one set is a misconfiguration that would
+	// otherwise send no credentials and fail with an opaque 401 at request time.
+	if (p.User == "") != (p.Password == "") {
+		return fmt.Errorf("PDU authentication requires both user and password to be set, or neither")
+	}
 
-	controlURL, err := url.Parse(strings.TrimRight(p.Host, "/") + "/control_outlet.htm")
+	req := &requester{
+		client:   &http.Client{Timeout: defaultTimeout},
+		user:     p.User,
+		password: p.Password,
+	}
+
+	backend, err := newBackend(p.Vendor, req, p.Host)
 	if err != nil {
 		return err
 	}
 
-	p.controlURL = controlURL
-
-	statusURL, err := url.Parse(strings.TrimRight(p.Host, "/") + "/status.xml")
-	if err != nil {
-		return err
-	}
-
-	p.statusURL = statusURL
+	p.backend = backend
 
 	return nil
 }
@@ -96,52 +194,112 @@ func (p *PDU) Deinit(_ context.Context) error {
 }
 
 func (p *PDU) Run(ctx context.Context, s module.Session, args ...string) error {
-	if p.client == nil {
-		return fmt.Errorf("PDU client not initialized")
-	}
-
-	if p.Host == "" {
-		return fmt.Errorf("PDU host address not configured")
+	if p.backend == nil {
+		return fmt.Errorf("PDU backend not initialized: Init must run successfully before Run")
 	}
 
 	if len(args) == 0 {
-		s.Println("No command specified. Call 'help' for usage.")
-
-		return nil
+		return fmt.Errorf("no command specified, available commands: %s", commandList())
 	}
 
 	cmd := strings.ToLower(args[0])
 
-	switch cmd {
-	case on, off, toggle:
-		return p.setPower(ctx, s, cmd)
-	case status:
-		return p.status(ctx, s)
-	default:
-		s.Println("Unknown command: " + cmd)
-		s.Println("Available commands: on, off, toggle, status")
+	if cmd == status {
+		return p.report(ctx, s)
+	}
 
-		return nil
+	act, ok := parseAction(cmd)
+	if !ok {
+		return fmt.Errorf("unknown command %q, available commands: %s", cmd, commandList())
+	}
+
+	return p.apply(ctx, s, act)
+}
+
+// apply performs the power action via the backend and reports the resulting state to the client.
+func (p *PDU) apply(ctx context.Context, s module.Session, act action) error {
+	result, err := p.backend.setPower(ctx, p.Outlet, act)
+	if err != nil {
+		return err
+	}
+
+	log.FromContext(ctx).Info("power command applied", "outlet", p.Outlet, "action", act, "state", result)
+	s.Printf("PDU outlet %d powered %s\n", p.Outlet, result)
+
+	return nil
+}
+
+// report queries the outlet state via the backend and reports it to the client.
+func (p *PDU) report(ctx context.Context, s module.Session) error {
+	current, err := p.backend.outletState(ctx, p.Outlet)
+	if err != nil {
+		return err
+	}
+
+	log.FromContext(ctx).Debug("power state queried", "outlet", p.Outlet, "state", current)
+	s.Printf("PDU outlet %d state: %s\n", p.Outlet, current)
+
+	return nil
+}
+
+// backend abstracts a vendor-specific PDU HTTP API. Implementations are chosen
+// by newBackend and carry everything they need to reach the device, so the PDU
+// module can drive any supported vendor through the same two operations.
+type backend interface {
+	// setPower applies the action to the outlet and returns the resulting state.
+	// Backends without a native toggle implement it as a read-modify-write.
+	setPower(ctx context.Context, outlet int, act action) (state, error)
+	// outletState reports the outlet's current power state.
+	outletState(ctx context.Context, outlet int) (state, error)
+}
+
+//nolint:ireturn // factory returns different backends behind one interface for vendor polymorphism.
+func newBackend(vendor string, req *requester, host string) (backend, error) {
+	base, err := url.Parse(host)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PDU host %q: %w", host, err)
+	}
+
+	if base.Scheme == "" || base.Host == "" {
+		return nil, fmt.Errorf("invalid PDU host %q: must be an absolute URL including scheme (e.g. http://10.0.0.5)", host)
+	}
+
+	switch vendor {
+	case "", vendorIntellinet: // An empty vendor keeps legacy configs on the Intellinet API.
+		return intellinet{req: req, base: base}, nil
+	case vendorGude:
+		return gude{req: req, base: base}, nil
+	default:
+		return nil, fmt.Errorf("unknown PDU vendor %q (supported: %q, %q)", vendor, vendorIntellinet, vendorGude)
 	}
 }
 
-// doRequest performs an authenticated GET request against url and returns the
-// response. On success the caller owns the response and must close its Body; on
-// any error the returned response is nil (its body already closed if one
-// existed). A non-200 status is reported as an error.
-func (p *PDU) doRequest(ctx context.Context, url string) (*http.Response, error) {
-	log.FromContext(ctx).Debug("GET " + url)
+// requester performs authenticated GET requests against a PDU's HTTP API. It
+// carries the credentials so vendor backends need not repeat the request setup.
+type requester struct {
+	client   *http.Client
+	user     string
+	password string
+}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+// get issues an authenticated GET against endpoint. On success the caller owns the
+// response and must close its Body; on any error the returned response is nil (its
+// body already closed if one existed). A non-200 status is reported as an error.
+func (r *requester) get(ctx context.Context, endpoint string) (*http.Response, error) {
+	authenticated := r.user != "" && r.password != ""
+
+	log.FromContext(ctx).Debug("GET "+endpoint, "auth", authenticated)
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	if p.User != "" && p.Password != "" {
-		req.SetBasicAuth(p.User, p.Password)
+	if authenticated {
+		request.SetBasicAuth(r.user, r.password)
 	}
 
-	resp, err := p.client.Do(req)
+	resp, err := r.client.Do(request)
 	if err != nil {
 		return nil, err
 	}
@@ -150,106 +308,8 @@ func (p *PDU) doRequest(ctx context.Context, url string) (*http.Response, error)
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 
-		return nil, fmt.Errorf("PDU command failed with status %s: %s", resp.Status, string(body))
+		return nil, fmt.Errorf("PDU request failed with status %s: %s", resp.Status, string(body))
 	}
 
 	return resp, nil
-}
-
-func (p *PDU) setPower(ctx context.Context, s module.Session, state string) error {
-	opState, err := parseOp(state)
-	if err != nil {
-		return err
-	}
-
-	q := p.controlURL.Query()
-	q.Set(fmt.Sprintf("outlet%d", p.Outlet), "1")
-	q.Set("op", opState.String())
-	p.controlURL.RawQuery = q.Encode()
-
-	resp, err := p.doRequest(ctx, p.controlURL.String())
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	log.FromContext(ctx).Info(fmt.Sprintf("outlet %d power %s", p.Outlet, state))
-	s.Printf("PDU outlet%d power set to '%s' successfully\n", p.Outlet, state)
-
-	return nil
-}
-
-func (p *PDU) status(ctx context.Context, s module.Session) error {
-	resp, err := p.doRequest(ctx, p.statusURL.String())
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	outletValue, err := p.parseOutletStatus(body)
-	if err != nil {
-		return err
-	}
-
-	s.Printf("PDU outlet%d state: %s\n", p.Outlet, outletValue)
-
-	return nil
-}
-
-// parseOutletStatus extracts the outlet status from XML response body.
-func (p *PDU) parseOutletStatus(body []byte) (string, error) {
-	bodyStr := string(body)
-
-	outletTag := fmt.Sprintf("<outletStat%d>", p.Outlet)
-	outletEndTag := fmt.Sprintf("</outletStat%d>", p.Outlet)
-
-	startIdx := strings.Index(bodyStr, outletTag)
-	if startIdx == -1 {
-		return "", fmt.Errorf("outlet %d not found in PDU status", p.Outlet)
-	}
-
-	startIdx += len(outletTag)
-
-	endIdx := strings.Index(bodyStr[startIdx:], outletEndTag)
-	if endIdx == -1 {
-		return "", fmt.Errorf("malformed XML for outlet %d", p.Outlet)
-	}
-
-	outletValue := strings.TrimSpace(bodyStr[startIdx : startIdx+endIdx])
-
-	if outletValue != on && outletValue != off {
-		return "", fmt.Errorf("unexpected outlet state '%s' for outlet %d", outletValue, p.Outlet)
-	}
-
-	return outletValue, nil
-}
-
-type op string
-
-const (
-	opOn     op = "0"
-	opOff    op = "1"
-	opToggle op = "2"
-)
-
-func (o op) String() string {
-	return string(o)
-}
-
-func parseOp(state string) (op, error) {
-	switch state {
-	case on:
-		return opOn, nil
-	case off:
-		return opOff, nil
-	case toggle:
-		return opToggle, nil
-	default:
-		return "", fmt.Errorf("invalid PDU operation: %s", state)
-	}
 }

--- a/pkg/module/pdu/pdu_test.go
+++ b/pkg/module/pdu/pdu_test.go
@@ -5,238 +5,248 @@
 package pdu
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
-func TestParseOutletStatus(t *testing.T) {
+// TestBackendSelection exercises the config decode + Init path that selects the
+// vendor backend, mirroring how pkg/dut unmarshals a module's "with" options.
+func TestBackendSelection(t *testing.T) {
 	tests := []struct {
-		name     string
-		outlet   int
-		xmlBody  string
-		expected string
-		err      bool
+		name    string
+		options string
+		want    backend
+		initErr bool
 	}{
 		{
-			name:   "outlet 0 on",
-			outlet: 0,
-			xmlBody: `<response>
-<outletStat0>on</outletStat0>
-<outletStat1>off</outletStat1>
-</response>`,
-			expected: "on",
-			err:      false,
+			name:    "explicit intellinet",
+			options: "vendor: intellinet\nhost: http://10.0.0.1\noutlet: 0\n",
+			want:    intellinet{},
 		},
 		{
-			name:   "outlet 1 off",
-			outlet: 1,
-			xmlBody: `<response>
-<outletStat0>on</outletStat0>
-<outletStat1>off</outletStat1>
-</response>`,
-			expected: "off",
-			err:      false,
+			name:    "gude",
+			options: "vendor: gude\nhost: http://10.0.0.1\noutlet: 0\n",
+			want:    gude{},
 		},
 		{
-			name:   "outlet 6 on with whitespace",
-			outlet: 6,
-			xmlBody: `<response>
-<outletStat6>  on  </outletStat6>
-</response>`,
-			expected: "on",
-			err:      false,
+			name:    "legacy config without vendor defaults to intellinet",
+			options: "host: http://10.0.0.1\noutlet: 0\n",
+			want:    intellinet{},
 		},
 		{
-			name:   "outlet not found",
-			outlet: 5,
-			xmlBody: `<response>
-<outletStat0>on</outletStat0>
-<outletStat1>off</outletStat1>
-</response>`,
-			expected: "",
-			err:      true,
+			name:    "unknown vendor is rejected at Init",
+			options: "vendor: acme\nhost: http://10.0.0.1\n",
+			initErr: true,
 		},
 		{
-			name:   "malformed XML - missing end tag",
-			outlet: 0,
-			xmlBody: `<response>
-<outletStat0>on
-</response>`,
-			expected: "",
-			err:      true,
+			name:    "user and password together are accepted",
+			options: "vendor: gude\nhost: http://10.0.0.1\nuser: admin\npassword: secret\n",
+			want:    gude{},
 		},
 		{
-			name:   "unexpected outlet state",
-			outlet: 0,
-			xmlBody: `<response>
-<outletStat0>unknown</outletStat0>
-</response>`,
-			expected: "",
-			err:      true,
+			name:    "user without password is rejected",
+			options: "host: http://10.0.0.1\nuser: admin\n",
+			initErr: true,
 		},
 		{
-			name:   "real PDU response example",
-			outlet: 6,
-			xmlBody: `<response>
-<cur0>0.2</cur0>
-<stat0>normal</stat0>
-<curBan>0.2</curBan>
-<tempBan>30</tempBan>
-<humBan>31</humBan>
-<statBan>normal</statBan>
-<outletStat0>on</outletStat0>
-<outletStat1>on</outletStat1>
-<outletStat2>on</outletStat2>
-<outletStat3>on</outletStat3>
-<outletStat4>on</outletStat4>
-<outletStat5>on</outletStat5>
-<outletStat6>on</outletStat6>
-<outletStat7>off</outletStat7>
-<userVerifyRes>0</userVerifyRes>
-</response>`,
-			expected: "on",
-			err:      false,
-		},
-		{
-			name:     "empty XML",
-			outlet:   0,
-			xmlBody:  "",
-			expected: "",
-			err:      true,
-		},
-		{
-			name:   "outlet number out of range",
-			outlet: 99,
-			xmlBody: `<response>
-<outletStat0>on</outletStat0>
-</response>`,
-			expected: "",
-			err:      true,
+			name:    "password without user is rejected",
+			options: "host: http://10.0.0.1\npassword: secret\n",
+			initErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &PDU{
-				Outlet: tt.outlet,
+			var p PDU
+			if err := yaml.Unmarshal([]byte(tt.options), &p); err != nil {
+				t.Fatalf("yaml.Unmarshal() unexpected error: %v", err)
 			}
 
-			result, err := p.parseOutletStatus([]byte(tt.xmlBody))
+			err := p.Init(context.Background())
 
-			if tt.err {
+			if tt.initErr {
 				if err == nil {
-					t.Errorf("parseOutletStatus() expected error but got none")
+					t.Fatalf("Init() expected error but got none")
 				}
+
 				return
 			}
 
 			if err != nil {
-				t.Errorf("parseOutletStatus() unexpected error: %v", err)
-				return
+				t.Fatalf("Init() unexpected error: %v", err)
 			}
 
-			if result != tt.expected {
-				t.Errorf("parseOutletStatus() = %v, expected %v", result, tt.expected)
+			if gotType, wantType := typeName(p.backend), typeName(tt.want); gotType != wantType {
+				t.Errorf("backend = %s, want %s", gotType, wantType)
 			}
 		})
 	}
 }
 
-func TestParseOp(t *testing.T) {
+func typeName(b backend) string {
+	switch b.(type) {
+	case intellinet:
+		return "intellinet"
+	case gude:
+		return "gude"
+	default:
+		return "nil"
+	}
+}
+
+func TestParseAction(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected op
-		err      bool
+		name  string
+		input string
+		want  action
+		ok    bool
 	}{
-		{
-			name:     "on command",
-			input:    "on",
-			expected: opOn,
-			err:      false,
-		},
-		{
-			name:     "off command",
-			input:    "off",
-			expected: opOff,
-			err:      false,
-		},
-		{
-			name:     "toggle command",
-			input:    "toggle",
-			expected: opToggle,
-			err:      false,
-		},
-		{
-			name:     "invalid command",
-			input:    "invalid",
-			expected: "",
-			err:      true,
-		},
-		{
-			name:     "empty command",
-			input:    "",
-			expected: "",
-			err:      true,
-		},
+		{name: "on", input: "on", want: turnOn, ok: true},
+		{name: "off", input: "off", want: turnOff, ok: true},
+		{name: "toggle", input: "toggle", want: toggle, ok: true},
+		{name: "status is not an action", input: "status", ok: false},
+		{name: "unknown", input: "bogus", ok: false},
+		{name: "empty", input: "", ok: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := parseOp(tt.input)
-
-			if tt.err {
-				if err == nil {
-					t.Errorf("parseOp() expected error but got none")
-				}
-				return
+			got, ok := parseAction(tt.input)
+			if ok != tt.ok {
+				t.Fatalf("parseAction(%q) ok = %v, want %v", tt.input, ok, tt.ok)
 			}
 
-			if err != nil {
-				t.Errorf("parseOp() unexpected error: %v", err)
-				return
-			}
-
-			if result != tt.expected {
-				t.Errorf("parseOp() = %v, expected %v", result, tt.expected)
+			if ok && got != tt.want {
+				t.Errorf("parseAction(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestOpString(t *testing.T) {
+func TestParseState(t *testing.T) {
 	tests := []struct {
-		name     string
-		op       op
-		expected string
+		name  string
+		input string
+		want  state
+		ok    bool
 	}{
-		{
-			name:     "opOn",
-			op:       opOn,
-			expected: "0",
-		},
-		{
-			name:     "opOff",
-			op:       opOff,
-			expected: "1",
-		},
-		{
-			name:     "opToggle",
-			op:       opToggle,
-			expected: "2",
-		},
-		{
-			name:     "invalid op",
-			op:       op("invalid"),
-			expected: "invalid",
-		},
+		{name: "on", input: "on", want: on, ok: true},
+		{name: "off", input: "off", want: off, ok: true},
+		{name: "toggle is not a state", input: "toggle", ok: false},
+		{name: "unknown", input: "bogus", ok: false},
+		{name: "empty", input: "", ok: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.op.String()
-			if result != tt.expected {
-				t.Errorf("op.String() = %v, expected %v", result, tt.expected)
+			got, ok := parseState(tt.input)
+			if ok != tt.ok {
+				t.Fatalf("parseState(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+			}
+
+			if ok && got != tt.want {
+				t.Errorf("parseState(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}
+}
+
+func TestStateString(t *testing.T) {
+	if got := on.String(); got != "on" {
+		t.Errorf("on.String() = %q, want %q", got, "on")
+	}
+
+	if got := off.String(); got != "off" {
+		t.Errorf("off.String() = %q, want %q", got, "off")
+	}
+}
+
+func TestActionString(t *testing.T) {
+	tests := []struct {
+		a    action
+		want string
+	}{
+		{a: turnOn, want: "on"},
+		{a: turnOff, want: "off"},
+		{a: toggle, want: "toggle"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.a.String(); got != tt.want {
+			t.Errorf("action.String() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+// TestRequesterGet documents the transport contract every backend relies on:
+// HTTP Basic Auth is sent only when both credentials are configured, and any
+// non-200 response is turned into an error with no response handed back.
+func TestRequesterGet(t *testing.T) {
+	t.Run("sends basic auth when credentials are set", func(t *testing.T) {
+		var (
+			gotUser, gotPass string
+			gotOK            bool
+		)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			gotUser, gotPass, gotOK = r.BasicAuth()
+		}))
+		defer srv.Close()
+
+		req := &requester{client: srv.Client(), user: "admin", password: "secret"}
+
+		resp, err := req.get(context.Background(), srv.URL)
+		if err != nil {
+			t.Fatalf("get() unexpected error: %v", err)
+		}
+		resp.Body.Close()
+
+		if !gotOK || gotUser != "admin" || gotPass != "secret" {
+			t.Errorf("basic auth = (%q, %q, ok=%v), want (admin, secret, ok=true)", gotUser, gotPass, gotOK)
+		}
+	})
+
+	t.Run("omits basic auth when credentials are empty", func(t *testing.T) {
+		var gotOK bool
+
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			_, _, gotOK = r.BasicAuth()
+		}))
+		defer srv.Close()
+
+		req := &requester{client: srv.Client()}
+
+		resp, err := req.get(context.Background(), srv.URL)
+		if err != nil {
+			t.Fatalf("get() unexpected error: %v", err)
+		}
+		resp.Body.Close()
+
+		if gotOK {
+			t.Errorf("basic auth was sent, want none")
+		}
+	})
+
+	t.Run("non-200 status is an error and returns no response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+		}))
+		defer srv.Close()
+
+		req := &requester{client: srv.Client()}
+
+		resp, err := req.get(context.Background(), srv.URL)
+		if err == nil {
+			resp.Body.Close()
+			t.Fatal("get() expected error for non-200 status, got nil")
+		}
+
+		if resp != nil {
+			t.Errorf("get() returned a response alongside the error, want nil")
+		}
+	})
 }


### PR DESCRIPTION
Supersedes #334. That PR targets a fork branch (`9elements/dutctl-9e`),
which runs a reduced CI set; reopening from an `origin` branch so the
full suite runs.

Original work by @JonasLoeffelholz (#334); rebased onto current `main`
and refactored for the post-#368 package layout.
