### PR TITLE
ci: make compatible with old fti

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -117,9 +117,7 @@ nfpms:
       - rpm
       - archlinux
     replaces:
-      - golang-github-fti
-      - golang-fti
-      - fti
+      - dutctl
     bindir: /usr/bin
     section: default
     priority: extra


### PR DESCRIPTION
- in the transition period, we will need to have both old fti and new dutctl preset on our systems
- therefore they should not be mutually exclusive
- the old fti binary will be renamed