### PR TITLE
Packaging fix: Allow dcpmd usage from dutagent service

### DIFF
--- a/packaging/dutagent.service
+++ b/packaging/dutagent.service
@@ -47,8 +47,7 @@ NoNewPrivileges=true
 LockPersonality=yes
 SystemCallArchitectures=native
 ## Restrict access to filesystem
-NoExecPaths=/
-ExecPaths=/usr/bin/dutagent
+### Exec path are not restricted to allow usage of tools like dpcmd and custom scripts
 ReadOnlyPaths=/
 ReadWritePaths=/var/lib/dutagent /var/log/dutagent
 

--- a/packaging/dutagent.sysusers
+++ b/packaging/dutagent.sysusers
@@ -8,3 +8,6 @@ m dutagent dutagent
 # Access to serial
 m dutagent uucp
 m dutagent dialout
+
+# Access to flasher
+m dutagent plugdev


### PR DESCRIPTION
Modified the user groups to have plugdev group, to use dpcmd without sudo.
Remove exec path restriction to allow dpcmd or any scripts execution.