### PR TITLE
Mark GitHub releases as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,18 @@ jobs:
       # keep the semver prerelease suffix (e.g. -alpha.N) when bumping, but it
       # also marks the GitHub Release as pre-release. The latter is not wanted,
       # so revert the marking right after the release is created.
-      - name: Unmark GitHub pre-release flag
+      #
+      # Unmarking alone does not move the repository's 'Latest' pointer:
+      # a release published as pre-release cannot become latest, and later
+      # edits only move the pointer when 'make_latest' is sent explicitly.
+      # Hence mark latest in a second call, once the release is a regular one.
+      - name: Unmark GitHub pre-release flag and mark release as latest
         if: ${{ steps.release.outputs.release_created }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit ${{ steps.release.outputs.tag_name }} --repo ${{ github.repository }} --prerelease=false
+        run: |
+          gh release edit ${{ steps.release.outputs.tag_name }} --repo ${{ github.repository }} --prerelease=false
+          gh release edit ${{ steps.release.outputs.tag_name }} --repo ${{ github.repository }} --latest
 
       - if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v7


### PR DESCRIPTION
Removing the pre-release marking after release creation is not enough to make the release show up as 'Latest': GitHub moves the latest pointer only when a release is published as a regular release (make_latest defaults to true for newly published releases, but pre-releases cannot be set as latest) or when an edit sends make_latest explicitly. Since release-please publishes the release as pre-release, do both: unmark, then set latest explicitly.

v1.0.0-alpha.2 was affected and has been fixed manually.