### PR TITLE
fix: stop the broker before the Run handler returns

### DIFF
--- a/cmds/dutagent/rpc.go
+++ b/cmds/dutagent/rpc.go
@@ -14,6 +14,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/BlindspotSoftware/dutctl/internal/auth"
 	"github.com/BlindspotSoftware/dutctl/internal/dutagent/locker"
+	"github.com/BlindspotSoftware/dutctl/internal/dutagent/session"
 	"github.com/BlindspotSoftware/dutctl/internal/fsm"
 	"github.com/BlindspotSoftware/dutctl/internal/keyword"
 	"github.com/BlindspotSoftware/dutctl/internal/log"
@@ -388,12 +389,24 @@ func (a *rpcService) Run(
 		}
 	}()
 
+	// The broker is created here, not where it is started, so that this handler
+	// owns its lifetime: stopping it on every exit path, before the auto-lock is
+	// released above and before the handler returns. Deferred for the same reason
+	// as the lock: a panic in a state function unwinds past the FSM, and fsm.Run
+	// also skips the remaining states once ctx is done, so no state function can
+	// guarantee this. The handler must not return while a worker is still sending
+	// - see session.Broker.Stop for what happens if it does. Stopping a broker
+	// the run never started is a no-op.
+	broker := &session.Broker{}
+	defer broker.Stop(ctx)
+
 	fsmArgs := runCmdArgs{
 		stream:     rpc.NewRunStream(stream),
 		deviceList: a.devices,
 		locker:     a.locker,
 		user:       user,
 		autoLock:   autoLock,
+		broker:     broker,
 	}
 
 	_, err = fsm.Run(ctx, fsmArgs, receiveCommandRPC)

--- a/cmds/dutagent/states.go
+++ b/cmds/dutagent/states.go
@@ -38,6 +38,11 @@ type runCmdArgs struct {
 	locker     *locker.Locker
 	user       string
 	autoLock   *autoLockHold
+	// broker carries module<->client traffic while the modules run. Run owns it:
+	// it must not outlive the handler (see session.Broker.Stop), and only a
+	// deferred stop in the handler covers every exit path, including a panic
+	// unwinding past the FSM.
+	broker *session.Broker
 
 	// fields for the states used during execution
 	cmdMsg      *pb.Command
@@ -187,10 +192,13 @@ func executeModules(ctx context.Context, args runCmdArgs) (runCmdArgs, fsm.State
 	ctx = log.With(log.WithScope(ctx, "agent"), "device", args.cmdMsg.GetDevice(), "command", args.cmdMsg.GetCommand())
 	l := log.FromContext(ctx)
 
-	broker := &session.Broker{}
+	// Deferred initialization of the broker and the moduleErr channel: only create
+	// if not already provided (Run supplies the broker so its deferred stop covers
+	// every exit path; tests may still pass their own).
+	if args.broker == nil {
+		args.broker = &session.Broker{}
+	}
 
-	// Deferred initialization of the moduleErr channel: only create if not already provided
-	// (tests may still pass a custom channel).
 	if args.moduleErrCh == nil {
 		args.moduleErrCh = make(chan error, 1)
 	}
@@ -198,7 +206,7 @@ func executeModules(ctx context.Context, args runCmdArgs) (runCmdArgs, fsm.State
 	rpcCtx := ctx
 	modCtx, modCtxCancel := context.WithCancel(rpcCtx)
 
-	moduleSession, brokerErrCh := broker.Start(modCtx, args.stream)
+	moduleSession, brokerErrCh := args.broker.Start(modCtx, args.stream)
 	args.brokerErrCh = brokerErrCh
 	args.session = moduleSession
 
@@ -302,9 +310,9 @@ func waitModules(ctx context.Context, args runCmdArgs) (runCmdArgs, fsm.State[ru
 		}
 	}
 
-	// Success: the auto-lock is released by the deferred cleanup in Run, which
-	// covers every exit path including a panic, so no explicit release state is
-	// needed here.
+	// Success: the auto-lock is released and the broker is stopped by the
+	// deferred cleanup in Run, which covers every exit path including a panic,
+	// so no explicit release state is needed here.
 	return args, nil, nil
 }
 

--- a/cmds/dutagent/states_test.go
+++ b/cmds/dutagent/states_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"connectrpc.com/connect"
 	"github.com/BlindspotSoftware/dutctl/internal/dutagent/locker"
+	"github.com/BlindspotSoftware/dutctl/internal/dutagent/session"
 	"github.com/BlindspotSoftware/dutctl/internal/fsm"
 	"github.com/BlindspotSoftware/dutctl/internal/test/fakes"
 	"github.com/BlindspotSoftware/dutctl/pkg/dut"
@@ -559,6 +562,104 @@ func TestExecuteModules(t *testing.T) {
 	}
 }
 
+// blockingStream is a session.Stream whose Send takes measurable time, standing
+// in for the real transport where a send is an http2 write that outlives the
+// call that triggered it. It records how many sends are in flight.
+type blockingStream struct {
+	sendFor  time.Duration
+	closed   chan struct{} // closed by the test to end the stream
+	inFlight atomic.Int32
+	sends    atomic.Int32
+}
+
+// Receive blocks until the test ends the stream, mimicking a client that holds
+// the stream open for the duration of the run. Returning io.EOF right away would
+// tear the broker down before the module even runs.
+func (s *blockingStream) Receive() (*pb.RunRequest, error) {
+	<-s.closed
+
+	return nil, io.EOF
+}
+
+func (s *blockingStream) Send(_ *pb.RunResponse) error {
+	s.sends.Add(1)
+	s.inFlight.Add(1)
+
+	defer s.inFlight.Add(-1)
+
+	time.Sleep(s.sendFor)
+
+	return nil
+}
+
+// printThenFailModule reproduces the shape of a failing flash module: it forwards
+// output to the client and only then returns the error that aborts the run.
+type printThenFailModule struct {
+	err error
+}
+
+func (m *printThenFailModule) Help() string                   { return "print then fail" }
+func (m *printThenFailModule) Init(_ context.Context) error   { return nil }
+func (m *printThenFailModule) Deinit(_ context.Context) error { return nil }
+func (m *printThenFailModule) Run(_ context.Context, s module.Session, _ ...string) error {
+	s.Print("flash tool output")
+
+	return m.err
+}
+
+// TestExecuteModulesBrokerStopEndsInFlightSend exercises the seam that crashed
+// the agent, with the real broker and in the shape the bug had: a module prints
+// and then fails, so a downstream send is still in flight when the run is
+// abandoned. The states themselves no longer stop the broker - the deferred stop
+// in Run does, which is what this test stands in for.
+func TestExecuteModulesBrokerStopEndsInFlightSend(t *testing.T) {
+	stream := &blockingStream{
+		sendFor: 100 * time.Millisecond,
+		closed:  make(chan struct{}),
+	}
+	defer close(stream.closed)
+
+	mod := dut.Module{Module: &printThenFailModule{err: errors.New("flash tool exited with code 1")}}
+	mod.Config.Name = "printThenFail"
+	mod.Config.Passthrough = true
+
+	// The broker Run creates and defers the stop of.
+	broker := &session.Broker{}
+	args := runCmdArgs{
+		stream: stream,
+		cmdMsg: &pb.Command{Device: "devX", Command: "flash"},
+		cmd:    dut.Command{Modules: []dut.Module{mod}},
+		broker: broker,
+	}
+
+	args, next, err := executeModules(context.Background(), args)
+	if err != nil {
+		t.Fatalf("unexpected error from executeModules: %v", err)
+	}
+
+	if !stateEqual(next, waitModules) {
+		t.Fatalf("unexpected next state: want %p got %p", waitModules, next)
+	}
+
+	_, _, err = waitModules(context.Background(), args)
+
+	var cErr *connect.Error
+	if !errors.As(err, &cErr) || cErr.Code() != connect.CodeAborted {
+		t.Fatalf("expected connect code %v, got %v", connect.CodeAborted, err)
+	}
+
+	// What Run's deferred stop does, before it lets the handler return.
+	broker.Stop(context.Background())
+
+	if stream.sends.Load() == 0 {
+		t.Fatal("no response reached the stream, the test does not exercise the seam")
+	}
+
+	if got := stream.inFlight.Load(); got != 0 {
+		t.Errorf("stop returned with %d send(s) in flight, the handler would finish underneath them", got)
+	}
+}
+
 func TestWaitModules(t *testing.T) {
 	// Design notes:
 	//  - We inject pre-buffered channels (size 1) for moduleErr and brokerErrCh directly into runCmdArgs.
@@ -595,6 +696,18 @@ func TestWaitModules(t *testing.T) {
 				return ctx, args
 			},
 			exp: expect{wantSuccess: true},
+		},
+		{
+			// A client that hangs up mid-run: neither channel ever reports, the
+			// RPC context is what ends the wait.
+			name: "rpc_context_cancelled",
+			setup: func() (context.Context, runCmdArgs) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				args := runCmdArgs{moduleErrCh: make(chan error, 1), brokerErrCh: make(chan error, 1)}
+				return ctx, args
+			},
+			exp: expect{wantErrCode: connect.CodeCanceled},
 		},
 		{
 			name: "success_broker_then_module",

--- a/internal/dutagent/session/broker.go
+++ b/internal/dutagent/session/broker.go
@@ -9,7 +9,10 @@ package session
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/BlindspotSoftware/dutctl/internal/log"
 	"github.com/BlindspotSoftware/dutctl/pkg/module"
@@ -31,12 +34,29 @@ const (
 // Broker mediates between a module and its environment while the module is executed.
 // This concerns communication and data exchange.
 type Broker struct {
+	// stopTimeout overrides how long Stop waits for the workers; zero uses
+	// defaultStopTimeout. It exists so tests can shorten the wait; production
+	// leaves it 0.
+	stopTimeout time.Duration
+
 	once    sync.Once
 	stream  Stream
 	session backend
 	errCh   chan error // closed after all workers complete
 	wg      sync.WaitGroup
+
+	// mu guards the teardown handles below. Start writes them, Stop reads them,
+	// and while the RPC handler does both from its own goroutine, nothing in the
+	// type's contract says a caller has to.
+	mu      sync.Mutex
+	cancel  context.CancelFunc // stops the workers; nil until Start ran
+	stopped chan struct{}      // closed after all workers returned
 }
+
+// defaultStopTimeout bounds how long Stop waits for the workers. A worker stuck
+// in a stream send past this window is abandoned: blocking the RPC handler
+// forever is the worse outcome.
+const defaultStopTimeout = 5 * time.Second
 
 func (b *Broker) init() {
 	b.session.printCh = make(chan string)
@@ -71,6 +91,12 @@ func (b *Broker) Start(ctx context.Context, s Stream) (module.Session, <-chan er
 		log.FromContext(ctx).Debug("broker initializing")
 
 		workerCtx, workerCancel := context.WithCancel(ctx)
+		stopped := make(chan struct{})
+
+		b.mu.Lock()
+		b.cancel = workerCancel
+		b.stopped = stopped
+		b.mu.Unlock()
 		// Freeze the workers' done signal onto the session so the module-facing
 		// methods (which carry no context) can abort a channel op whose worker
 		// peer has exited. Set here, before the workers start and before Start
@@ -84,6 +110,11 @@ func (b *Broker) Start(ctx context.Context, s Stream) (module.Session, <-chan er
 
 		go func() {
 			b.wg.Wait()
+			// Both closes mean the same thing - every worker has returned from its
+			// last stream call - so their order is not load-bearing; stopped is
+			// closed first only to keep Stop's signal ahead of the one the RPC
+			// layer drains.
+			close(stopped)
 			close(b.errCh)
 		}()
 	})
@@ -92,15 +123,88 @@ func (b *Broker) Start(ctx context.Context, s Stream) (module.Session, <-chan er
 	return &b.session, b.errCh
 }
 
+// Stop cancels the workers and waits for them to return. Calling it on a Broker
+// that was never started, or calling it twice, is a no-op.
+//
+// The RPC handler must not return while a worker is still inside a stream send.
+// connect invalidates the response writer once the handler is gone, and a send
+// running past that point does not fail - it panics with "Write called after
+// Handler finished" in the worker goroutine. net/http recovers a panic in the
+// handler itself, but not in a goroutine the handler left behind, so the panic
+// takes the whole agent down. A module that prints right before it fails (the
+// flash module forwards the flash tool's output, then returns the tool's exit
+// error) hits that window on every failed run.
+//
+// A worker stuck in a send past the stop timeout is abandoned, so the panic is
+// not structurally impossible - it is bounded to a genuinely hung transport
+// write, where the alternative is a handler that never returns. The workers
+// recover from it (see toClient/fromClient) so the agent survives that case too.
+func (b *Broker) Stop(ctx context.Context) {
+	b.mu.Lock()
+	cancel, stopped := b.cancel, b.stopped
+	b.mu.Unlock()
+
+	if cancel == nil {
+		return // never started
+	}
+
+	cancel()
+
+	stopTimeout := b.stopTimeout
+	if stopTimeout == 0 {
+		stopTimeout = defaultStopTimeout
+	}
+
+	timeout := time.NewTimer(stopTimeout)
+	defer timeout.Stop()
+
+	select {
+	case <-stopped:
+	case <-timeout.C:
+		log.FromContext(ctx).Warn("workers did not stop in time", "timeout", stopTimeout)
+	}
+}
+
+// recoverWorker turns a panic in a worker goroutine into a failed run and stops
+// the companion worker. A worker panics where its own recover cannot help it: a
+// stream send that outlives the RPC handler panics inside net/http, and the
+// goroutine sits outside the handler, so an unrecovered panic there takes the
+// whole agent down - including every other run in flight. Stop keeps that send
+// from outliving the handler in the first place; this is the net for a worker it
+// had to abandon at its timeout.
+//
+// The panic is reported on errCh like any other worker failure, so the run fails
+// instead of looking like a broker that finished cleanly. The send neither blocks
+// nor hits a closed channel: errCh holds one slot per worker, a worker reports
+// either a panic or a terminal error but never both, and errCh is closed only
+// once both workers have returned - which is after this recover.
+func (b *Broker) recoverWorker(l *slog.Logger, cancel context.CancelFunc) {
+	r := recover()
+	if r == nil {
+		return
+	}
+
+	l.Error("worker panicked", "err", r)
+
+	select {
+	case b.errCh <- fmt.Errorf("session worker panicked: %v", r):
+	default:
+	}
+
+	cancel()
+}
+
 func (b *Broker) toClient(ctx context.Context, cancel context.CancelFunc) {
 	// Scope the downstream (agent → client) flow; the worker and its chanio
 	// reader inherit it from ctx.
 	ctx = log.WithScope(ctx, scopeSessionDownstream)
 
 	go func() {
-		defer b.wg.Done()
-
 		l := log.FromContext(ctx)
+
+		defer b.wg.Done()
+		defer b.recoverWorker(l, cancel)
+
 		l.Debug("worker started")
 
 		err := toClientWorker(ctx, b.stream, &b.session)
@@ -124,9 +228,11 @@ func (b *Broker) fromClient(ctx context.Context, cancel context.CancelFunc) {
 	ctx = log.WithScope(ctx, scopeSessionUpstream)
 
 	go func() {
-		defer b.wg.Done()
-
 		l := log.FromContext(ctx)
+
+		defer b.wg.Done()
+		defer b.recoverWorker(l, cancel)
+
 		l.Debug("worker started")
 
 		err := fromClientWorker(ctx, b.stream, &b.session)

--- a/internal/dutagent/session/broker_test.go
+++ b/internal/dutagent/session/broker_test.go
@@ -11,8 +11,11 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/BlindspotSoftware/dutctl/pkg/module"
 
 	pb "github.com/BlindspotSoftware/dutctl/protobuf/gen/dutctl/v1"
 )
@@ -403,5 +406,170 @@ func TestBrokerReceiveLoopExitsOnCancel(t *testing.T) {
 				runtime.NumGoroutine(), base)
 		case <-time.After(10 * time.Millisecond):
 		}
+	}
+}
+
+// These tests cover Stop, the guarantee the RPC handler relies on: when Stop
+// returns, no worker is inside a stream call any more. A handler that returns
+// while one is takes the whole agent down, see Broker.Stop.
+
+// slowStream is a Stream whose Send takes measurable time and can be made to
+// block indefinitely or to panic, standing in for a transport where a send
+// outlives the call that triggered it.
+type slowStream struct {
+	sendFor   time.Duration
+	sendBlock chan struct{} // if non-nil, Send waits for it to close
+	sendPanic bool
+	closed    chan struct{} // closed by the test to end the stream
+	inFlight  atomic.Int32
+	sends     atomic.Int32
+}
+
+// Receive blocks until the test ends the stream, mimicking a client that keeps
+// it open for the duration of the run. An immediate io.EOF would tear the
+// broker down before there is anything to stop.
+func (s *slowStream) Receive() (*pb.RunRequest, error) {
+	<-s.closed
+
+	return nil, io.EOF
+}
+
+func (s *slowStream) Send(_ *pb.RunResponse) error {
+	s.sends.Add(1)
+	s.inFlight.Add(1)
+
+	defer s.inFlight.Add(-1)
+
+	if s.sendPanic {
+		panic("Write called after Handler finished")
+	}
+
+	if s.sendBlock != nil {
+		<-s.sendBlock
+	}
+
+	time.Sleep(s.sendFor)
+
+	return nil
+}
+
+// printFrom drives one Print through the session, so a send is in flight.
+func printFrom(t *testing.T, s module.Session) {
+	t.Helper()
+
+	done := make(chan struct{})
+
+	go func() {
+		s.Print("module output")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Print did not reach a worker")
+	}
+}
+
+func TestBrokerStopWaitsForInFlightSend(t *testing.T) {
+	stream := &slowStream{sendFor: 100 * time.Millisecond, closed: make(chan struct{})}
+	defer close(stream.closed)
+
+	b := &Broker{}
+	sesh, _ := b.Start(context.Background(), stream)
+
+	printFrom(t, sesh)
+
+	b.Stop(context.Background())
+
+	if stream.sends.Load() == 0 {
+		t.Fatal("no send happened, the test does not exercise the seam")
+	}
+
+	if got := stream.inFlight.Load(); got != 0 {
+		t.Errorf("Stop returned with %d send(s) in flight", got)
+	}
+}
+
+func TestBrokerStopAbandonsStuckWorker(t *testing.T) {
+	stream := &slowStream{sendBlock: make(chan struct{}), closed: make(chan struct{})}
+
+	defer close(stream.closed)
+	defer close(stream.sendBlock)
+
+	// Shortened so the test does not wait out the production timeout.
+	const stopTimeout = 100 * time.Millisecond
+
+	b := &Broker{stopTimeout: stopTimeout}
+	sesh, _ := b.Start(context.Background(), stream)
+
+	printFrom(t, sesh)
+
+	start := time.Now()
+
+	b.Stop(context.Background())
+
+	waited := time.Since(start)
+
+	// Stop must have tried: anything quicker than its own timeout means it did
+	// not wait for the worker at all.
+	if waited < stopTimeout {
+		t.Errorf("Stop returned after %v, it did not wait out its %v timeout", waited, stopTimeout)
+	}
+
+	// Blocking the handler forever is the worse outcome, so Stop gives up. The
+	// send it abandoned is still running - that is what the workers' recover is
+	// for.
+	if waited > time.Second {
+		t.Errorf("Stop waited %v for a stuck worker, it must give up at its timeout", waited)
+	}
+
+	if got := stream.inFlight.Load(); got != 1 {
+		t.Errorf("expected the abandoned send to still be in flight, got %d", got)
+	}
+}
+
+func TestBrokerStopWithoutStartAndTwice(t *testing.T) {
+	b := &Broker{}
+
+	start := time.Now()
+
+	b.Stop(context.Background()) // never started
+
+	stream := &testStream{recvErrs: []error{io.EOF}}
+	b.Start(context.Background(), stream)
+
+	b.Stop(context.Background())
+	b.Stop(context.Background())
+
+	// None of these has anything to wait for, so none may spend its timeout.
+	if waited := time.Since(start); waited > time.Second {
+		t.Errorf("stopping an unstarted or already stopped broker took %v", waited)
+	}
+}
+
+// TestBrokerWorkerPanicIsRecovered covers the case Stop cannot prevent: a send
+// abandoned at the stop timeout panics later, in a goroutine outside the RPC
+// handler's recover. Unrecovered, that takes the whole agent - and every other
+// run in flight - down with it. The run must fail with it, not look like a
+// broker that finished cleanly.
+func TestBrokerWorkerPanicIsRecovered(t *testing.T) {
+	stream := &slowStream{sendPanic: true, closed: make(chan struct{})}
+	defer close(stream.closed)
+
+	b := &Broker{}
+	sesh, errCh := b.Start(context.Background(), stream)
+
+	printFrom(t, sesh)
+
+	// The workers must terminate on their own after the panic, not hang.
+	errs := collectErrors(t, errCh, time.Second)
+
+	if len(errs) != 1 {
+		t.Fatalf("expected the panic to be reported once, got %v", errs)
+	}
+
+	if !strings.Contains(errs[0].Error(), "panicked") {
+		t.Errorf("error does not name the panic: %v", errs[0])
 	}
 }


### PR DESCRIPTION
## The bug

`dutagent` died with a panic whenever a module printed something and then failed:

```
panic: Write called after Handler finished
	panic: Header called after Handler finished
connectrpc.com/connect.flushResponseWriter → net/http.(*http2responseWriter).Flush
	.../internal/dutagent/session.toClientWorker → worker.go:41
```

`session.Print` is a rendezvous: it returns as soon as a worker has *taken* the
message, not when the message is on the wire. The worker is then still inside
`stream.Send` while the module already returns its error, the FSM finishes and
`Run` returns. connect invalidates the response writer once the handler is gone,
so that send does not fail - it panics. `net/http` recovers a panic in the
handler itself, but not in a goroutine the handler left behind, so this took the
whole agent down, including every other run in flight. `Restart=always` hides it
as a climbing `NRestarts` and a dropped connection for concurrent clients.

The flash module hits this window on every failed run: it forwards the flash
tool's output and then returns the tool's exit error, so a `dpcmd` exiting
non-zero was enough to kill the agent.

## The fix

- `session.Broker.Stop` cancels the workers and waits for them to return,
  signalled by a new `stopped` channel closed after `wg.Wait()`. `errCh` keeps
  its existing contract; only `Stop` reads `stopped`, so the two never steal each
  other's values.
- `Run` owns the broker now: it creates it and stops it in a deferred cleanup,
  registered after the auto-lock release so it runs *before* it - the device is
  handed on only once the workers are gone. Ownership sits where the lifetime
  ends, and no state function has to remember anything.
  A state function could not carry this guarantee: it does not cover a panic
  unwinding past the FSM, `fsm.Run` skips the remaining states once ctx is done,
  and every future early return in the handler would reopen the hole.
- A worker stuck in a send past the stop timeout (5 s) is abandoned - a handler
  that never returns is the worse outcome. For that leftover case the workers now
  recover from a panic and report it on `errCh`, so the run fails instead of the
  process, and a panicking worker no longer looks like a broker that finished
  cleanly.

## Tests

`internal/dutagent/session`: `Stop` waits for an in-flight send, gives up on a
stuck worker at its own timeout, is a no-op when the broker was never started or
is stopped twice, and a worker panic is recovered *and* surfaced as an error.

`cmds/dutagent`: the seam with the real broker - a module prints, then fails, and
no send is in flight once the broker is stopped. Plus the cancelled-RPC case in
`TestWaitModules`.

Every new test was checked against a deliberately broken version of the code:

```
Stop as a no-op:        Stop returned with 1 send(s) in flight
                        Stop returned after 80ns, it did not wait out its 100ms timeout
panic not reported:     expected the panic to be reported once, got []
ctx.Done branch gutted: expected error code canceled, got nil
recover removed:        the test binary dies with the original panic
```

## Verification

`go test -race ./...`, `golangci-lint run ./...` and `go vet ./...` are clean.

Ran against real hardware (a Raspberry Pi agent driving an Alderlake-P board):
the same failing `flash read` that used to kill the agent now returns
`flash operation failed: flash tool exited with code 1` to the client, the worker
stops first, and `NRestarts` stays at 0.

## Left open, deliberately

- `session.Print` still returns before its send completes. The window is closed
  by the deferred stop, but the asymmetry remains.
- The module goroutine runs on the RPC context, so on a broker failure it keeps
  running after `Run` returned. That is pre-existing and worth its own issue, not
  this fix.
- Nothing drives `Run` itself in tests - `connect.BidiStream` has no exported
  constructor - so the deferred stop is wired but only covered indirectly. The
  same is true of the pre-existing auto-lock release. An `httptest`-based test
  like `internal/rpc/version_external_test.go` could close both.
