### PR TITLE
feat: file transfers are checksummed end to end

### DIFF
--- a/.firmwareci/workflows/workflow-rpi-dutctl-tester/tests/file.yaml
+++ b/.firmwareci/workflows/workflow-rpi-dutctl-tester/tests/file.yaml
@@ -29,6 +29,12 @@ stages:
         parameters:
           command: "echo 'uploaded-by-file-module' > upload-source.txt"
 
+      - cmd: shell
+        name: Clear a stale upload from an earlier run
+        transport: *transport_root
+        parameters:
+          command: "rm -f /tmp/dutctl-fwci-upload.txt"
+
       - cmd: cmd
         name: Upload the file to the dutagent
         transport:
@@ -42,6 +48,8 @@ stages:
               "upload",
               "upload-source.txt",
             ]
+          expect:
+            - regex: "sent \"upload-source.txt\" \\(.*sha256 8c33bbe7f8bc"
         options:
           timeout: 15s
 
@@ -72,6 +80,8 @@ stages:
               "download",
               "download-target.txt",
             ]
+          expect:
+            - regex: "received \"download-target.txt\" \\(.*sha256 62d71bcc7f71"
         options:
           timeout: 15s
 
@@ -85,8 +95,41 @@ stages:
           expect:
             - regex: "downloaded-by-file-module"
 
+      - cmd: copy
+        name: Copy the corrupting proxy to the dutagent
+        transport: *transport_oscar
+        parameters:
+          source: "[[input.CORRUPT_PROXY]]"
+          destination: "/tmp/corrupt-proxy.py"
+
+      - cmd: shell
+        name: Start the corrupting proxy
+        transport: *transport_oscar
+        parameters:
+          command: "kill \"$(cat /tmp/corrupt-proxy.pid 2>/dev/null)\" 2>/dev/null || true; setsid nohup python3 /tmp/corrupt-proxy.py --listen 0.0.0.0:2025 --target 127.0.0.1:[[attributes.DutagentPort]] --marker uploaded-by-file-module > /tmp/corrupt-proxy.log 2>&1 < /dev/null & echo $! > /tmp/corrupt-proxy.pid; sleep 1; cat /tmp/corrupt-proxy.log"
+          expect:
+            - regex: "marker 'uploaded-by-file-module'"
+
+      - cmd: shell
+        name: A corrupted upload is rejected
+        transport:
+          proto: local
+        parameters:
+          command: "[[input.DUTCTL]] -s [[attributes.Host]]:2025 [[attributes.DeviceName]] upload upload-source.txt 2>&1 || true"
+          expect:
+            - regex: "file corrupted in transit"
+            - regex: "want 8c33bbe7f8bcb95148b49fe1aeccb0f6b6cb755f3bbc3b4a07832617d4688f7e"
+        options:
+          timeout: 30s
+
+      - cmd: shell
+        name: Stop the corrupting proxy
+        transport: *transport_oscar
+        parameters:
+          command: "kill \"$(cat /tmp/corrupt-proxy.pid 2>/dev/null)\" 2>/dev/null || true; rm -f /tmp/corrupt-proxy.py /tmp/corrupt-proxy.pid /tmp/corrupt-proxy.log"
+
       - cmd: shell
         name: Remove the transferred files from the dutagent
-        transport: *transport_oscar
+        transport: *transport_root
         parameters:
           command: "rm -f /tmp/dutctl-fwci-upload.txt /tmp/dutctl-fwci-download.txt || true"

--- a/.github/workflows/fwci-test.yml
+++ b/.github/workflows/fwci-test.yml
@@ -87,7 +87,7 @@ jobs:
           TOKEN: "${{ secrets.FWCI_TOKEN }}"
           WORKFLOW_NAME: test-dutctl
           COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
-          BINARIES: DUTCTL=${{ steps.filenames.outputs.dutctl_path }};REMOTE_PKG=${{ steps.filenames.outputs.dutctl_pkg_path }};CONFIG=./test/test-dutagent-cfg.yaml;TASKFILE=./.firmwareci/Taskfile.yml;DUMMY_SPI_FLASH_ROM=./.firmwareci/dummy_binary.rom
+          BINARIES: DUTCTL=${{ steps.filenames.outputs.dutctl_path }};REMOTE_PKG=${{ steps.filenames.outputs.dutctl_pkg_path }};CONFIG=./test/test-dutagent-cfg.yaml;TASKFILE=./.firmwareci/Taskfile.yml;DUMMY_SPI_FLASH_ROM=./.firmwareci/dummy_binary.rom;CORRUPT_PROXY=./test/corrupt-proxy.py
           GITHUB_INSTALLATION_ID: 45795153
 
 

--- a/cmds/dutagent/errmap_test.go
+++ b/cmds/dutagent/errmap_test.go
@@ -40,8 +40,9 @@ func TestCancelCode(t *testing.T) {
 }
 
 // TestBrokerError locks the broker-error wire-status classification: a client
-// protocol violation is CodeInvalidArgument, an already-typed connect error keeps
-// its code, and anything else is CodeInternal.
+// protocol violation is CodeInvalidArgument, a corrupted transfer is
+// CodeDataLoss, an already-typed connect error keeps its code, and anything
+// else is CodeInternal.
 func TestBrokerError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -49,6 +50,7 @@ func TestBrokerError(t *testing.T) {
 		want connect.Code
 	}{
 		{"bad file transfer", fmt.Errorf("%w: empty file", session.ErrBadFileTransfer), connect.CodeInvalidArgument},
+		{"corrupt file transfer", fmt.Errorf("%w: %q", session.ErrFileCorrupt, "fw.bin"), connect.CodeDataLoss},
 		{"typed connect code preserved", connect.NewError(connect.CodeCanceled, errors.New("client gone")), connect.CodeCanceled},
 		{"plain error is internal", errors.New("boom"), connect.CodeInternal},
 	}

--- a/cmds/dutagent/states.go
+++ b/cmds/dutagent/states.go
@@ -270,7 +270,8 @@ func executeModules(ctx context.Context, args runCmdArgs) (runCmdArgs, fsm.State
 // Errors: CodeCanceled/CodeDeadlineExceeded on context cancellation (via
 // cancelCode); CodeAborted on a module failure; and for a broker error,
 // CodeInvalidArgument for a client protocol violation (session.ErrBadFileTransfer),
-// an already-typed connect code preserved, else CodeInternal (via brokerError).
+// CodeDataLoss for a corrupted transfer (session.ErrFileCorrupt), an
+// already-typed connect code preserved, else CodeInternal (via brokerError).
 func waitModules(ctx context.Context, args runCmdArgs) (runCmdArgs, fsm.State[runCmdArgs], error) {
 	brokerDone := false
 	moduleDone := false
@@ -349,7 +350,8 @@ func moduleError(err error) error {
 
 // brokerError maps a terminal broker error to the connect error that fails the
 // Run: a client protocol violation (session.ErrBadFileTransfer) is
-// CodeInvalidArgument, an already-typed connect error (e.g. CodeCanceled on
+// CodeInvalidArgument, a transfer the transport damaged (session.ErrFileCorrupt)
+// is CodeDataLoss, an already-typed connect error (e.g. CodeCanceled on
 // client disconnect) keeps its code, and anything else is an internal fault.
 func brokerError(err error) error {
 	var connectErr *connect.Error
@@ -357,6 +359,8 @@ func brokerError(err error) error {
 	switch {
 	case errors.Is(err, session.ErrBadFileTransfer):
 		return connect.NewError(connect.CodeInvalidArgument, err)
+	case errors.Is(err, session.ErrFileCorrupt):
+		return connect.NewError(connect.CodeDataLoss, err)
 	case errors.As(err, &connectErr):
 		return err
 	default:

--- a/cmds/dutctl/rpc.go
+++ b/cmds/dutctl/rpc.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/BlindspotSoftware/dutctl/internal/digest"
 	"github.com/BlindspotSoftware/dutctl/internal/output"
 	"github.com/BlindspotSoftware/dutctl/pkg/headers"
 
@@ -330,11 +331,14 @@ func (app *application) runRPC(ctx context.Context, device, command string, cmdA
 					return
 				}
 
+				sum := digest.Sum(content)
+
 				err = stream.Send(&pb.RunRequest{
 					Msg: &pb.RunRequest_File{
 						File: &pb.File{
 							Path:    path,
 							Content: content,
+							Sha256:  sum,
 						},
 					},
 				})
@@ -345,16 +349,35 @@ func (app *application) runRPC(ctx context.Context, device, command string, cmdA
 				}
 
 				app.formatter.WriteContent(output.Content{
-					Type:     output.TypeFileTransfer,
-					Data:     output.FileTransfer{Direction: "sent", Path: path, Bytes: len(content)},
+					Type: output.TypeFileTransfer,
+					Data: output.FileTransfer{
+						Direction: "sent",
+						Path:      path,
+						Bytes:     len(content),
+						SHA256:    digest.Hex(sum),
+					},
 					Metadata: metadata,
 				})
 			case *pb.RunResponse_File:
 				path := msg.File.GetPath()
 				content := msg.File.GetContent()
+				want := msg.File.GetSha256()
 
 				if len(content) == 0 {
 					slog.Warn("received empty file content", "path", path)
+				}
+
+				sum := digest.Sum(content)
+
+				// Verified before the write: corrupted bytes must not reach disk.
+				switch {
+				case digest.Missing(want):
+					slog.Warn("agent sent no checksum, file not verified", "path", path)
+				case !digest.Match(sum, want):
+					errChan <- fmt.Errorf("received file %q: %w: want %s, got %s (%d bytes)",
+						path, digest.ErrMismatch, digest.Hex(want), digest.Hex(sum), len(content))
+
+					return
 				}
 
 				perm := 0600
@@ -367,8 +390,13 @@ func (app *application) runRPC(ctx context.Context, device, command string, cmdA
 				}
 
 				app.formatter.WriteContent(output.Content{
-					Type:     output.TypeFileTransfer,
-					Data:     output.FileTransfer{Direction: "received", Path: path, Bytes: len(content)},
+					Type: output.TypeFileTransfer,
+					Data: output.FileTransfer{
+						Direction: "received",
+						Path:      path,
+						Bytes:     len(content),
+						SHA256:    digest.Hex(sum),
+					},
 					Metadata: metadata,
 				})
 

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package digest computes and compares the content digests that accompany file
+// transfers between the dutctl client and the dutagent.
+//
+// Connect and TCP validate framing, not content. A path that damages bytes and
+// recomputes checksums (a NIC offload engine re-splitting packets for a
+// userspace VPN, for one) delivers a full-length, well-formed, wrong file that
+// nothing else in dutctl would notice.
+package digest
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+)
+
+// ErrMismatch reports content that does not hash to the digest sent with it.
+// Callers wrap it with the file and both digests.
+var ErrMismatch = errors.New("content does not match its digest")
+
+// Sum returns the SHA-256 of content, the form carried in File.sha256.
+func Sum(content []byte) []byte {
+	sum := sha256.Sum256(content)
+
+	return sum[:]
+}
+
+// Missing reports whether a peer omitted the digest, which happens only when it
+// predates the field. Kept apart from [Match] so an absent digest can warn
+// while a wrong one fails.
+func Missing(want []byte) bool {
+	return len(want) == 0
+}
+
+// Match reports whether a digest computed by [Sum] equals the one received.
+func Match(sum, want []byte) bool {
+	return bytes.Equal(sum, want)
+}
+
+// Hex renders a digest as lowercase hex. Abbreviating it for display is left to
+// the caller.
+func Hex(sum []byte) string {
+	return hex.EncodeToString(sum)
+}

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package digest_test
+
+import (
+	"testing"
+
+	"github.com/BlindspotSoftware/dutctl/internal/digest"
+)
+
+// knownSum is the SHA-256 of "abc", the canonical NIST test vector, so a change
+// of algorithm cannot pass unnoticed.
+const knownSum = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
+func TestSumKnownVector(t *testing.T) {
+	if got := digest.Hex(digest.Sum([]byte("abc"))); got != knownSum {
+		t.Errorf("Sum(\"abc\") = %s, want %s", got, knownSum)
+	}
+}
+
+func TestSumLength(t *testing.T) {
+	if got := len(digest.Sum(nil)); got != 32 {
+		t.Errorf("digest length = %d, want 32", got)
+	}
+}
+
+func TestMatch(t *testing.T) {
+	content := []byte("firmware")
+	sum := digest.Sum(content)
+
+	if !digest.Match(sum, digest.Sum(content)) {
+		t.Error("Match on identical content = false, want true")
+	}
+
+	// A single flipped byte, the shape the transport corruption took.
+	corrupt := append([]byte(nil), content...)
+	corrupt[0] ^= 0x01
+
+	if digest.Match(digest.Sum(corrupt), sum) {
+		t.Error("Match on altered content = true, want false")
+	}
+}
+
+func TestMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		want []byte
+		miss bool
+	}{
+		{"nil", nil, true},
+		{"empty", []byte{}, true},
+		{"present", digest.Sum([]byte("x")), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := digest.Missing(tt.want); got != tt.miss {
+				t.Errorf("Missing = %v, want %v", got, tt.miss)
+			}
+		})
+	}
+}

--- a/internal/dutagent/session/worker.go
+++ b/internal/dutagent/session/worker.go
@@ -11,6 +11,7 @@ import (
 	"io"
 
 	"github.com/BlindspotSoftware/dutctl/internal/chanio"
+	"github.com/BlindspotSoftware/dutctl/internal/digest"
 	"github.com/BlindspotSoftware/dutctl/internal/log"
 
 	pb "github.com/BlindspotSoftware/dutctl/protobuf/gen/dutctl/v1"
@@ -20,6 +21,11 @@ import (
 // violation) so the RPC layer can map it to CodeInvalidArgument rather than
 // treating it as an internal fault.
 var ErrBadFileTransfer = errors.New("bad file transfer")
+
+// ErrFileCorrupt marks content that does not match the digest the client sent
+// with it: the transport damaged it. Distinct from ErrBadFileTransfer, which is
+// the client misbehaving, so the RPC layer can map the two differently.
+var ErrFileCorrupt = errors.New("file corrupted in transit")
 
 // toClientWorker sends messages from the module session to the client.
 // It loops until ctx is cancelled (returning nil) or a stream send fails
@@ -97,6 +103,7 @@ func toClientWorker(ctx context.Context, stream Stream, s *backend) error {
 					File: &pb.File{
 						Path:    name,
 						Content: content,
+						Sha256:  digest.Sum(content),
 					},
 				},
 			}
@@ -233,7 +240,24 @@ func fromClientWorker(ctx context.Context, stream Stream, s *backend) error {
 					return fmt.Errorf("%w: received file-message %q but requested %q", ErrBadFileTransfer, path, want)
 				}
 
-				l.Debug("received file from client", "name", path, "bytes", len(content))
+				// Verified before the module sees the bytes.
+				wantSum := fileMsg.GetSha256()
+				sum := digest.Sum(content)
+
+				switch {
+				case digest.Missing(wantSum):
+					l.Warn("client sent no checksum, file not verified", "name", path)
+				case !digest.Match(sum, wantSum):
+					// Logged as well as returned: tearing down the stream can beat
+					// the status to the client, which then only sees a write error.
+					l.Error("file corrupted in transit", "name", path,
+						"want", digest.Hex(wantSum), "got", digest.Hex(sum), "bytes", len(content))
+
+					return fmt.Errorf("%w: %q: want %s, got %s (%d bytes)", ErrFileCorrupt,
+						path, digest.Hex(wantSum), digest.Hex(sum), len(content))
+				}
+
+				l.Debug("received file from client", "name", path, "bytes", len(content), "sha256", digest.Hex(sum))
 
 				file := make(chan []byte, 1)
 

--- a/internal/dutagent/session/worker_test.go
+++ b/internal/dutagent/session/worker_test.go
@@ -1,0 +1,166 @@
+// Copyright 2025 Blindspot Software
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package session
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/BlindspotSoftware/dutctl/internal/digest"
+
+	pb "github.com/BlindspotSoftware/dutctl/protobuf/gen/dutctl/v1"
+)
+
+func fileRequest(path string, content, sum []byte) *pb.RunRequest {
+	return &pb.RunRequest{
+		Msg: &pb.RunRequest_File{
+			File: &pb.File{Path: path, Content: content, Sha256: sum},
+		},
+	}
+}
+
+// TestFromClientWorker_Digest covers the three digest outcomes on an incoming
+// file: verified, unverifiable (peer predates the field), and corrupted.
+func TestFromClientWorker_Digest(t *testing.T) {
+	const path = "fw.bin"
+
+	content := []byte("firmware payload")
+	corruptSum := digest.Sum([]byte("something else entirely"))
+
+	tests := []struct {
+		name    string
+		sum     []byte
+		wantErr error
+	}{
+		{name: "verified", sum: digest.Sum(content)},
+		{name: "no digest is accepted", sum: nil},
+		{name: "mismatch is rejected", sum: corruptSum, wantErr: ErrFileCorrupt},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &backend{fileCh: make(chan chan []byte, 1)}
+			s.setCurrentFile(path)
+
+			stream := &testStream{recvReqs: []*pb.RunRequest{fileRequest(path, content, tt.sum)}}
+
+			err := fromClientWorker(context.Background(), stream, s)
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tt.wantErr)
+				}
+
+				if !strings.Contains(err.Error(), digest.Hex(tt.sum)) {
+					t.Errorf("err = %q, want it to name the expected digest", err)
+				}
+
+				if len(s.fileCh) != 0 {
+					t.Error("corrupted file was handed to the module")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected err = %v", err)
+			}
+
+			select {
+			case file := <-s.fileCh:
+				if got := string(<-file); got != string(content) {
+					t.Errorf("module received %q, want %q", got, content)
+				}
+			default:
+				t.Fatal("no file handed to the module")
+			}
+		})
+	}
+}
+
+// TestToClientWorker_SendsDigest asserts an outgoing file carries its digest,
+// so the client can verify what the agent sent.
+func TestToClientWorker_SendsDigest(t *testing.T) {
+	content := []byte("result log")
+
+	s := &backend{fileCh: make(chan chan []byte, 1)}
+	s.setCurrentFile("result.log")
+
+	file := make(chan []byte, 1)
+	file <- content
+	close(file)
+
+	s.fileCh <- file
+
+	stream := newCaptureStream()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- toClientWorker(ctx, stream, s) }()
+
+	sent := stream.await(t)
+
+	cancel()
+
+	if err := <-done; err != nil {
+		t.Fatalf("toClientWorker err = %v", err)
+	}
+
+	got := sent.GetFile().GetSha256()
+	if !digest.Match(got, digest.Sum(content)) {
+		t.Errorf("sent digest = %s, want %s", digest.Hex(got), digest.Hex(digest.Sum(content)))
+	}
+}
+
+// captureStream records what the agent sends to the client.
+type captureStream struct {
+	mu   sync.Mutex
+	msgs []*pb.RunResponse
+	sent chan struct{}
+}
+
+func newCaptureStream() *captureStream {
+	return &captureStream{sent: make(chan struct{}, 1)}
+}
+
+func (s *captureStream) Send(res *pb.RunResponse) error {
+	s.mu.Lock()
+	s.msgs = append(s.msgs, res)
+	s.mu.Unlock()
+
+	select {
+	case s.sent <- struct{}{}:
+	default:
+	}
+
+	return nil
+}
+
+func (s *captureStream) Receive() (*pb.RunRequest, error) {
+	return nil, io.EOF
+}
+
+// await blocks until a message has been sent and returns the first one.
+func (s *captureStream) await(t *testing.T) *pb.RunResponse {
+	t.Helper()
+
+	select {
+	case <-s.sent:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for a sent message")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.msgs[0]
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -48,11 +48,13 @@ type DeviceEntry struct {
 }
 
 // FileTransfer describes a file sent to or received from the agent for
-// TypeFileTransfer output. Direction is "sent" or "received".
+// TypeFileTransfer output. Direction is "sent" or "received". SHA256 is the
+// content digest as lowercase hex, so a job log identifies the bytes that moved.
 type FileTransfer struct {
-	Direction string `json:"direction" yaml:"direction"`
-	Path      string `json:"path"      yaml:"path"`
-	Bytes     int    `json:"bytes"     yaml:"bytes"`
+	Direction string `json:"direction"        yaml:"direction"`
+	Path      string `json:"path"             yaml:"path"`
+	Bytes     int    `json:"bytes"            yaml:"bytes"`
+	SHA256    string `json:"sha256,omitempty" yaml:"sha256,omitempty"`
 }
 
 // Content is a structured data unit to be formatted and displayed.

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -249,7 +249,8 @@ func (f *TextFormatter) writeLockResultTo(content Content, writer io.Writer) {
 }
 
 // writeFileTransferTo formats and writes a file-transfer progress line, e.g.
-// `↑ sent "firmware.bin" (1.2 MiB)` / `↓ received "result.log" (4.0 KiB)`.
+// `↑ sent "firmware.bin" (1.2 MiB, sha256 4d6b5416b5c5…)`. The digest is
+// omitted when the peer sent none.
 func (f *TextFormatter) writeFileTransferTo(content Content, writer io.Writer) {
 	transfer, ok := content.Data.(FileTransfer)
 	if !ok {
@@ -265,8 +266,25 @@ func (f *TextFormatter) writeFileTransferTo(content Content, writer io.Writer) {
 		marker = style.MarkerReceived
 	}
 
-	line := fmt.Sprintf("%s %s %q (%s)", marker, transfer.Direction, transfer.Path, humanBytes(transfer.Bytes))
+	detail := humanBytes(transfer.Bytes)
+	if transfer.SHA256 != "" {
+		detail += ", sha256 " + shortDigest(transfer.SHA256)
+	}
+
+	line := fmt.Sprintf("%s %s %q (%s)", marker, transfer.Direction, transfer.Path, detail)
 	fmt.Fprintln(writer, style.Colorize(f.useColor, style.Cyan, line))
+}
+
+// shortDigestLen keeps the transfer line readable; the JSON and YAML formats
+// carry the full digest.
+const shortDigestLen = 12
+
+func shortDigest(hexDigest string) string {
+	if len(hexDigest) <= shortDigestLen {
+		return hexDigest
+	}
+
+	return hexDigest[:shortDigestLen] + "…"
 }
 
 // writeCommandListTo formats and writes a list of commands with bullet points.

--- a/internal/output/text_test.go
+++ b/internal/output/text_test.go
@@ -409,6 +409,16 @@ func TestWriteFileTransfer(t *testing.T) {
 			data: FileTransfer{Direction: "received", Path: "result.log", Bytes: 4096},
 			want: "↓ received \"result.log\" (4.0 KiB)\n",
 		},
+		{
+			name: "with digest",
+			data: FileTransfer{
+				Direction: "sent",
+				Path:      "firmware.bin",
+				Bytes:     1258291,
+				SHA256:    "4d6b5416b5c54810cfef68584f0b6e6bacd00cdc",
+			},
+			want: "↑ sent \"firmware.bin\" (1.2 MiB, sha256 4d6b5416b5c5…)\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -86,6 +86,9 @@ type Module interface {
 // opaquely (no sentinel to match) and typically means the client declined the file
 // or the transfer stream failed.
 //
+// Transfers are checksummed by the framework, so a module never sees content
+// that was damaged in transit; the run fails first.
+//
 // Console, Print, RequestFile and SendFile must be called only from the module's
 // Run goroutine.
 type Session interface {

--- a/protobuf/dutctl/v1/dutctl.proto
+++ b/protobuf/dutctl/v1/dutctl.proto
@@ -114,6 +114,7 @@ message FileRequest {
 message File {
   string path = 1;
   bytes content = 2;
+  bytes sha256 = 3; // Raw 32-byte SHA-256 of content. Empty only from peers predating this field.
 }
 
 // LockRequest is sent by the client to acquire or extend a lock on a device.

--- a/protobuf/gen/dutctl/v1/dutctl.pb.go
+++ b/protobuf/gen/dutctl/v1/dutctl.pb.go
@@ -890,6 +890,7 @@ type File struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
 	Content       []byte                 `protobuf:"bytes,2,opt,name=content,proto3" json:"content,omitempty"`
+	Sha256        []byte                 `protobuf:"bytes,3,opt,name=sha256,proto3" json:"sha256,omitempty"` // Raw 32-byte SHA-256 of content. Empty only from peers predating this field.
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -934,6 +935,13 @@ func (x *File) GetPath() string {
 func (x *File) GetContent() []byte {
 	if x != nil {
 		return x.Content
+	}
+	return nil
+}
+
+func (x *File) GetSha256() []byte {
+	if x != nil {
+		return x.Sha256
 	}
 	return nil
 }
@@ -1283,10 +1291,11 @@ const file_dutctl_v1_dutctl_proto_rawDesc = "" +
 	"\x06stderr\x18\x03 \x01(\fH\x00R\x06stderrB\x06\n" +
 	"\x04data\"!\n" +
 	"\vFileRequest\x12\x12\n" +
-	"\x04path\x18\x01 \x01(\tR\x04path\"4\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\"L\n" +
 	"\x04File\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x18\n" +
-	"\acontent\x18\x02 \x01(\fR\acontent\"P\n" +
+	"\acontent\x18\x02 \x01(\fR\acontent\x12\x16\n" +
+	"\x06sha256\x18\x03 \x01(\fR\x06sha256\"P\n" +
 	"\vLockRequest\x12\x16\n" +
 	"\x06device\x18\x01 \x01(\tR\x06device\x12)\n" +
 	"\x10duration_seconds\x18\x02 \x01(\x03R\x0fdurationSeconds\"P\n" +

--- a/test/corrupt-proxy.py
+++ b/test/corrupt-proxy.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Copyright 2025 Blindspot Software
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+"""TCP proxy that corrupts one file transfer, for the dutctl checksum test.
+
+It forwards client-to-agent traffic untouched until it sees a marker, then
+flips one byte inside it, once, and forwards the result. The payload keeps its
+length and the kernel recomputes the TCP checksum over the damaged bytes, so
+the stream stays well-formed and only the file content is wrong. That is the
+property that made the real fault (a router offload engine re-splitting packets
+for a userspace VPN) invisible to every layer below the digest.
+
+Targeting the marker rather than a byte offset keeps the corruption inside the
+file payload, so it cannot land in an HTTP/2 frame header and desynchronise the
+stream instead of damaging the file.
+
+Usage:
+    corrupt-proxy.py --listen 0.0.0.0:2025 --target 127.0.0.1:2024 \
+                     --marker uploaded-by-file-module
+"""
+
+import argparse
+import socket
+import sys
+import threading
+
+
+def endpoint(value):
+    """Parse host:port into a (host, port) tuple."""
+    host, _, port = value.rpartition(":")
+    if not host or not port:
+        raise argparse.ArgumentTypeError(f"expected host:port, got {value!r}")
+
+    return host, int(port)
+
+
+class Corrupter:
+    """Flips one byte inside the first marker occurrence it sees."""
+
+    def __init__(self, marker):
+        self.marker = marker
+        self.done = threading.Event()
+
+    def apply(self, data):
+        if self.done.is_set():
+            return data
+
+        at = data.find(self.marker)
+        if at < 0:
+            return data
+
+        self.done.set()
+        flip = at + len(self.marker) // 2
+        print(f"corrupted byte at offset {flip} of a {len(data)}-byte chunk", flush=True)
+
+        return data[:flip] + bytes([data[flip] ^ 0x01]) + data[flip + 1:]
+
+
+def pump(src, dst, corrupter):
+    """Forward src to dst until EOF, corrupting when a corrupter is given."""
+    while True:
+        try:
+            data = src.recv(65536)
+        except OSError:
+            break
+
+        if not data:
+            break
+
+        if corrupter is not None:
+            data = corrupter.apply(data)
+
+        try:
+            dst.sendall(data)
+        except OSError:
+            break
+
+    try:
+        dst.shutdown(socket.SHUT_WR)
+    except OSError:
+        pass
+
+
+def handle(client, target, corrupter):
+    upstream = socket.create_connection(target)
+    # Only the client-to-agent direction is corrupted: that is the path a
+    # firmware image takes on its way to the emulator.
+    threading.Thread(target=pump, args=(client, upstream, corrupter), daemon=True).start()
+    pump(upstream, client, None)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--listen", type=endpoint, required=True, help="host:port to accept on")
+    parser.add_argument("--target", type=endpoint, required=True, help="host:port of the dutagent")
+    parser.add_argument("--marker", required=True, help="byte string to corrupt inside")
+    args = parser.parse_args()
+
+    corrupter = Corrupter(args.marker.encode())
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(args.listen)
+    srv.listen(8)
+    print(f"proxy {args.listen} -> {args.target}, marker {args.marker!r}", flush=True)
+
+    while True:
+        conn, _ = srv.accept()
+        threading.Thread(target=handle, args=(conn, args.target, corrupter), daemon=True).start()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Client and agent exchange a SHA-256 with every file and verify it before the content is used, so a transport that damages data is reported rather than passed on. Peers without the digest keep working and log a warning.