### PR TITLE
fix: agent can open serial ports and programmers

### DIFF
--- a/packaging/dutagent.service
+++ b/packaging/dutagent.service
@@ -53,6 +53,10 @@ ReadWritePaths=/var/lib/dutagent /var/log/dutagent
 ## Allow GPIO access (Raspberry Pi)
 DeviceAllow=/dev/gpiomem rw
 DeviceAllow=/dev/mem rw
+## Any device left out is refused with EPERM, group membership does not help
+DeviceAllow=char-ttyUSB rw
+DeviceAllow=char-ttyAMA rw
+DeviceAllow=char-usb_device rw
 
 # Networking
 SocketBindDeny=any


### PR DESCRIPTION
DeviceAllow turns the cgroup device policy into a whitelist, so adding the GPIO grant blocked every serial port and USB programmer with EPERM. List the tty and usb_device classes the modules drive.